### PR TITLE
Plugin model is all but complete

### DIFF
--- a/cmd/automate.go
+++ b/cmd/automate.go
@@ -108,7 +108,7 @@ var plunderAutomatePluginTest = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		log.SetLevel(log.Level(logLevel))
 
-		test := `{ "name": "Test", "action":"example/test", "plugin": { "test":"hello", "test1": 12345, "test2": true } }`
+		test := `{ "name": "Example of test action", "type": "exampleAction/test", "plugin": { "credentials": "AAABBBCCCCDDEEEE", "address": "172.0.0.1" }	}`
 		var action parlay.Action
 		_ = json.Unmarshal([]byte(test), &action)
 

--- a/pkg/parlay/parlay.go
+++ b/pkg/parlay/parlay.go
@@ -1,5 +1,7 @@
 package parlay
 
+import "encoding/json"
+
 type actionType string
 
 const (
@@ -66,7 +68,7 @@ type Action struct {
 	ETCD etcdMembers `json:"etcd,omitempty"`
 
 	//Plugin Spec
-	Plugin map[string]interface{} `json:"plugin,omitempty"`
+	Plugin json.RawMessage `json:"plugin,omitempty"`
 }
 
 // KeyMap

--- a/pkg/parlay/plugin/plugin.go
+++ b/pkg/parlay/plugin/plugin.go
@@ -1,6 +1,7 @@
 package parlayplugin
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -152,7 +153,7 @@ func UsagePlugin(pluginPath, action string) {
 		return
 	}
 
-	pluginExec, ok := symbol.(func(string) (string, error))
+	pluginExec, ok := symbol.(func(string) (map[string]interface{}, error))
 	if !ok {
 		log.Errorf("Unable to read functions from Plugin [%s]", pluginPath)
 		return
@@ -162,7 +163,14 @@ func UsagePlugin(pluginPath, action string) {
 		log.Errorf("%v", err)
 		return
 	}
-	fmt.Printf("%s\n", result)
+
+	a := parlay.Action{
+		Name:       fmt.Sprintf("Example name for action [%s]", action),
+		ActionType: action,
+		Plugin:     result,
+	}
+	b, _ := json.MarshalIndent(a, "", "\t")
+	fmt.Printf("%s\n", b)
 }
 
 // ExecuteAction uses the cache to find an action/plugin mapping

--- a/plugin/example.go
+++ b/plugin/example.go
@@ -51,9 +51,9 @@ func ParlayActions(action string, iface interface{}) []parlay.Action {
 
 // ParlayUsage - Returns the json that matches the specific action
 // <- action is a string that defines which action the usage information should be
-// -> iface is a map[string]interface{} that maps to the internal struct
+// <- raw - raw JSON that will be manipulated into a correct struct that matches the action
 // -> err is any error that has been generated
-func ParlayUsage(action string) (iface map[string]interface{}, err error) {
+func ParlayUsage(action string) (raw json.RawMessage, err error) {
 	switch action {
 	case "exampleAction/test":
 		a := pluginTestAction{
@@ -61,27 +61,23 @@ func ParlayUsage(action string) (iface map[string]interface{}, err error) {
 			Address:     "172.0.0.1",
 		}
 		// In order to turn a struct into an map[string]interface we need to turn it into JSON
-		inStruct, _ := json.Marshal(a)
-		json.Unmarshal(inStruct, &iface)
-		return
+
+		return json.Marshal(a)
 	default:
-		return iface, fmt.Errorf("Action [%s] could not be found", action)
+		return raw, fmt.Errorf("Action [%s] could not be found", action)
 	}
 }
 
 // ParlayExec - Parses the action and the data that the action will consume
 // <- action a string that details the action to be executed
-// <- iface - map[string]interface that will be manipulated into a correct struct that matches the action
+// <- raw - raw JSON that will be manipulated into a correct struct that matches the action
 // -> actions are an array of generated actions that the parser will then execute
 // -> err is any error that has been generated
-func ParlayExec(action string, iface interface{}) (actions []parlay.Action, err error) {
-
-	// Turn the interface into JSON
-	b, _ := json.Marshal(iface)
+func ParlayExec(action string, raw json.RawMessage) (actions []parlay.Action, err error) {
 
 	var t pluginTestAction
 	// Unmarshall the JSON into the struct
-	json.Unmarshal(b, &t)
+	json.Unmarshal(raw, &t)
 	// We can now use the fields as part of the struct
 	fmt.Printf("Address = %s\nCredentials = %s\n", t.Address, t.Credentials)
 


### PR DESCRIPTION
This addition details all of the encoding back and forth from a GO `struct` to an `interface{}`

From documentation it appears that usually the only method to pass an unknown struct back and forth between a plugin and an application is:

1. `struct` -> `map[string]interface{}`
2. Application passes `map[string]interface{}` to plugin
3. Plugin then turns `map[string]interface{}` to JSON and then unmarshalls it to the plugin `struct`

Process is reversed when passing example usage back to main application.