### PR TITLE
Added anyboot functionality

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -23,6 +23,8 @@ var gateway, dns, startAddress, configPath, deploymentPath *string
 
 var leasecount *int
 
+var anyboot *bool
+
 func init() {
 
 	// Find an example nic to use, that isn't the loopback address
@@ -58,6 +60,7 @@ func init() {
 	// Config File
 	configPath = PlunderServer.Flags().String("config", "", "Path to a plunder server configuration")
 	deploymentPath = PlunderServer.Flags().String("deployment", "", "Path to a plunder deployment configuration")
+	anyboot = PlunderServer.Flags().Bool("anyboot", false, "Should be used without a configuration, this will boot the kernel/initrd")
 	plunderCmd.AddCommand(PlunderServer)
 }
 
@@ -70,6 +73,9 @@ var PlunderServer = &cobra.Command{
 
 		// If deploymentPath is not blank then the flag has been used
 		if *deploymentPath != "" {
+			if *anyboot == true {
+				log.Errorf("AnyBoot has been enabled, all configuration will be ignored")
+			}
 			log.Infof("Reading deployment configuration from [%s]", *deploymentPath)
 			if _, err := os.Stat(*deploymentPath); !os.IsNotExist(err) {
 				deployment, err := ioutil.ReadFile(*deploymentPath)
@@ -81,6 +87,10 @@ var PlunderServer = &cobra.Command{
 					log.Fatalf("%v", err)
 				}
 			}
+		}
+
+		if *anyboot == true {
+			bootstraps.AnyBoot = true
 		}
 
 		// If configPath is not blank then the flag has been used

--- a/pkg/bootstraps/generator.go
+++ b/pkg/bootstraps/generator.go
@@ -10,6 +10,9 @@ import (
 	log "github.com/Sirupsen/logrus"
 )
 
+// AnyBoot - This flag when set to true will just boot any kernel/initrd/cmdline configuration
+var AnyBoot bool
+
 // DeploymentConfig - contains an accessable "current" configuration
 var DeploymentConfig DeploymentConfigurationFile
 
@@ -115,6 +118,12 @@ func UpdateConfiguration(configFile []byte) error {
 
 //FindDeployment - this will return the deployment configuration, allowing the DHCP server to return the correct DHCP options
 func FindDeployment(mac string) string {
+
+	// AnyBoot will just boot the specified kernel/initrd
+	if AnyBoot == true {
+		return "anyboot"
+	}
+
 	if len(DeploymentConfig.Deployments) == 0 {
 		// No configurations have been loaded
 		log.Warnln("Attempted to perform Mac Address lookup, however no configurations have been loaded")

--- a/pkg/server/serve_http.go
+++ b/pkg/server/serve_http.go
@@ -14,12 +14,13 @@ import (
 )
 
 // These strings container the generated iPXE details that are passed to the bootloader when the correct url is requested
-var preseed, kickstart, reboot string
+var preseed, kickstart, anyBoot, reboot string
 
 func (c *BootController) serveHTTP() error {
 
 	preseed = utils.IPXEPreeseed(*c.HTTPAddress, *c.Kernel, *c.Initrd, *c.Cmdline)
 	kickstart = utils.IPXEKickstart(*c.HTTPAddress, *c.Kernel, *c.Initrd, *c.Cmdline)
+	anyBoot = utils.IPXEAnyBoot(*c.HTTPAddress, *c.Kernel, *c.Initrd, *c.Cmdline)
 	reboot = utils.IPXEReboot()
 	docroot, err := filepath.Abs("./")
 	if err != nil {
@@ -34,6 +35,7 @@ func (c *BootController) serveHTTP() error {
 	http.HandleFunc("/preseed.ipxe", preseedHandler)
 	http.HandleFunc("/reboot.ipxe", rebootHandler)
 	http.HandleFunc("/kickstart.ipxe", kickstartHandler)
+	http.HandleFunc("/anyboot.ipxe", anyBootHandler)
 
 	// Update Endpoints - allow the update of various configuration without restarting
 	//http.HandleFunc("/config", kickstartHandler) // TODO
@@ -54,6 +56,13 @@ func kickstartHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/plain")
 	// Return the kickstart content
 	io.WriteString(w, kickstart)
+}
+
+func anyBootHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	w.Header().Set("Content-Type", "text/plain")
+	// Return the kickstart content
+	io.WriteString(w, anyBoot)
 }
 
 func rebootHandler(w http.ResponseWriter, r *http.Request) {

--- a/pkg/utils/ipxe.go
+++ b/pkg/utils/ipxe.go
@@ -66,6 +66,19 @@ boot
 	return iPXEHeader + buildScript
 }
 
+// IPXEAnyBoot - This will build an iPXE boot script for anything wanting to PXE boot
+func IPXEAnyBoot(webserverAddress string, kernel string, initrd string, cmdline string) string {
+	script := `
+kernel http://%s/%s auto=true url=http://%s/${mac:hexhyp}.cfg %s 
+initrd http://%s/%s
+boot
+`
+	// Replace the addresses inline
+	buildScript := fmt.Sprintf(script, webserverAddress, kernel, webserverAddress, cmdline, webserverAddress, initrd)
+
+	return iPXEHeader + buildScript
+}
+
 // PullPXEBooter - This will attempt to download the iPXE bootloader
 func PullPXEBooter() error {
 	log.Infoln("Beginning of iPXE download... ")


### PR DESCRIPTION
Without a deployment config then no servers will be deployed, this option adds the capability to pass a `--anyBoot` flag, where it will pass a simple config of just the kernel/initrd and the cmdline

Example for LinuxKit:

```
sudo ./plunder server --enableDHCP --enableTFTP --enableHTTP \
 --initrd ./linuxkit/linuxkit-initrd.img --kernel linuxkit/linuxkit-kernel --cmdline $(cat ./linuxkit/linuxkit-cmdline) \
--addressDHCP 192.168.1.1  --addressTFTP 192.1.1.1   --addressHTTP 192.168.1.1 \
--startAddress 192.168.1.130 --adapter ens192 --anyboot
```