### PR TITLE
A new UI command to the automation section

### DIFF
--- a/pkg/parlay/parlay_ui.go
+++ b/pkg/parlay/parlay_ui.go
@@ -1,0 +1,97 @@
+package parlay
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/AlecAivazis/survey"
+)
+
+func contains(v string, a []string) bool {
+	for _, i := range a {
+		if strings.Contains(v, i) {
+			return true
+		}
+	}
+	return false
+}
+
+// StartUI will enable parlay to provide an easier way of selecting which operations will be performed
+func (m *TreasureMap) StartUI() (*TreasureMap, error) {
+
+	deployments := []string{}
+	for i := range m.Deployments {
+		deployments = append(deployments, m.Deployments[i].Name)
+	}
+	if len(deployments) == 0 {
+		return nil, fmt.Errorf("No Deployments were found")
+	}
+
+	var multiQs = []*survey.Question{
+		{
+			Name: "letter",
+			Prompt: &survey.MultiSelect{
+				Message: "Select deployment(s)",
+				Options: deployments,
+			},
+		},
+	}
+	deploymentAnswers := []string{}
+
+	// ask the question
+	err := survey.Ask(multiQs, &deploymentAnswers)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a new TreasureMap from the answered questions
+	newMap, err := m.findDeployments(deploymentAnswers)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range newMap.Deployments {
+
+		// Ask for Hosts
+		multiQs[0].Prompt = &survey.MultiSelect{
+			Message: fmt.Sprintf("Select Hosts(s) for [%s]", newMap.Deployments[i].Name),
+			Options: newMap.Deployments[i].Hosts,
+		}
+
+		hostAnswers := []string{}
+		err := survey.Ask(multiQs, &hostAnswers)
+		if err != nil {
+			return nil, err
+		}
+
+		// Ask for Actions
+		actions := []string{}
+		for y := range newMap.Deployments[i].Actions {
+			actions = append(actions, m.Deployments[i].Actions[y].Name)
+		}
+
+		if len(actions) == 0 {
+			return nil, fmt.Errorf("No Deployments were found")
+		}
+		multiQs[0].Prompt = &survey.MultiSelect{
+			Message: fmt.Sprintf("Select Actions(s) for [%s]", newMap.Deployments[i].Name),
+			Options: actions,
+		}
+
+		deploymentAnswers := []string{}
+		err = survey.Ask(multiQs, &deploymentAnswers)
+		if err != nil {
+			return nil, err
+		}
+
+		newMap.Deployments[i].Hosts = hostAnswers
+		foundActions, err := newMap.Deployments[i].findActions(deploymentAnswers)
+		if err != nil {
+			return nil, err
+		}
+		newMap.Deployments[i].Actions = foundActions
+	}
+
+	return newMap, nil
+}

--- a/pkg/parlay/parser.go
+++ b/pkg/parlay/parser.go
@@ -17,6 +17,60 @@ import (
 
 var restore Restore
 
+func (m *TreasureMap) findDeployments(deployment []string) (*TreasureMap, error) {
+
+	var newDeploymentList []Deployment
+
+	for x := range deployment {
+		for y := range m.Deployments {
+			if m.Deployments[y].Name == deployment[x] {
+				newDeploymentList = append(newDeploymentList, m.Deployments[y])
+			}
+		}
+	}
+	// If this is zero it means that no deployments have been found
+	if len(m.Deployments) == 0 {
+		return nil, fmt.Errorf("No Deployment(s) have been found")
+	}
+	m.Deployments = newDeploymentList
+	return m, nil
+}
+
+func (d *Deployment) findHosts(hosts []string) (*Deployment, error) {
+
+	var newHostList []string
+
+	for x := range hosts {
+		for y := range d.Hosts {
+			if d.Hosts[y] == hosts[x] {
+				newHostList = append(newHostList, d.Hosts[y])
+			}
+		}
+	}
+	// If this is zero it means that no hosts have been found
+	if len(d.Hosts) == 0 {
+		return nil, fmt.Errorf("No Host(s) have been found")
+	}
+	d.Hosts = newHostList
+	return d, nil
+}
+
+func (d *Deployment) findActions(actions []string) ([]types.Action, error) {
+	var newActionList []types.Action
+	for x := range actions {
+		for y := range d.Hosts {
+			if d.Actions[y].Name == actions[x] {
+				newActionList = append(newActionList, d.Actions[y])
+			}
+		}
+	}
+	// If this is zero it means that no hosts have been found
+	if len(d.Actions) == 0 {
+		return nil, fmt.Errorf("No Action(s) have been found")
+	}
+	return newActionList, nil
+}
+
 //FindDeployment - takes a number of flags and builds a new map to be processed
 func (m *TreasureMap) FindDeployment(deployment, action, host, logFile string, resume bool) error {
 	var foundMap TreasureMap
@@ -27,10 +81,10 @@ func (m *TreasureMap) FindDeployment(deployment, action, host, logFile string, r
 				foundMap.Deployments = append(foundMap.Deployments, m.Deployments[x])
 				// Find a specific action and add or resume from
 				if action != "" {
+					// Clear the slice as we will be possibly adding different actions
+					foundMap.Deployments[0].Actions = nil
 					for y := range m.Deployments[x].Actions {
 						if m.Deployments[x].Actions[y].Name == action {
-							// Clear the slice as we will be possibly adding different actions
-							foundMap.Deployments[0].Actions = nil
 							// If we're not resuming that just add the action that we want to happen
 							if resume != true {
 								foundMap.Deployments[0].Actions = append(foundMap.Deployments[0].Actions, m.Deployments[x].Actions[y])
@@ -38,16 +92,19 @@ func (m *TreasureMap) FindDeployment(deployment, action, host, logFile string, r
 								// Alternatively add all actions from this point
 								foundMap.Deployments[0].Actions = m.Deployments[x].Actions[y:]
 							}
-							// If this is zero it means that no actions have been found
-							if len(foundMap.Deployments[0].Actions) == 0 {
-								return fmt.Errorf("No actions have been found, looking for action [%s]", action)
-							}
 						}
+					}
+					// If this is zero it means that no actions have been found
+					if len(foundMap.Deployments[0].Actions) == 0 {
+						return fmt.Errorf("No actions have been found, looking for action [%s]", action)
 					}
 				}
 				// If a host is specified act soley on it
 				if host != "" {
+					// Clear the slice as we will be possibly adding different actions
+					foundMap.Deployments[0].Hosts = nil
 					for y := range m.Deployments[x].Hosts {
+
 						if m.Deployments[x].Hosts[y] == host {
 							foundMap.Deployments[0].Hosts = append(foundMap.Deployments[0].Hosts, m.Deployments[x].Hosts[y])
 						}


### PR DESCRIPTION
This PR adds the capability to have a CLI User-interface to make customising an existing deployment much easier, also provides functionality to create a new deployment file that can be used seperatly.

Additions:
- a `ui` sub-command providing the capability to select Deployments, Hosts, Actions.
- a `--json` that wont execute commands, but will print the new JSON to stdout.

Fixes:
- An issue that prevented selecting a specif host to deploy on
- Tidied the flags for `automate` sub-command