### PR TITLE
Ssh pipe

### DIFF
--- a/pkg/parlay/parser.go
+++ b/pkg/parlay/parser.go
@@ -315,7 +315,7 @@ func parallelDeployment(action []types.Action, hosts []ssh.HostSSHConfig) error 
 
 				return err
 			}
-			crs := ssh.ParalellExecute(command, hosts, action[y].Timeout)
+			crs := ssh.ParalellExecute(command, action[y].CommandPipeFile, hosts, action[y].Timeout)
 			var errors bool // This will only be set to true if a command fails
 			for x := range crs {
 				if crs[x].Error != nil {
@@ -396,7 +396,7 @@ func parseAndExecute(a types.Action, h *ssh.HostSSHConfig) ssh.CommandResult {
 		cr.Result = strings.TrimRight(string(b), "\r\n")
 	} else {
 		log.Debugf("Executing command [%s] on host [%s]", command, h.Host)
-		cr = ssh.SingleExecute(command, *h, a.Timeout)
+		cr = ssh.SingleExecute(command, a.CommandPipeFile, *h, a.Timeout)
 
 		cr.Result = strings.TrimRight(cr.Result, "\r\n")
 

--- a/pkg/parlay/types/types.go
+++ b/pkg/parlay/types/types.go
@@ -24,6 +24,7 @@ type Action struct {
 	CommandSaveFile  string `json:"commandSaveFile,omitempty"`
 	CommandSaveAsKey string `json:"commandSaveAsKey,omitempty"`
 	CommandSudo      string `json:"commandSudo,omitempty"`
+	CommandPipeFile  string `json:"commandPipeFile,omitempty"`
 
 	// Key operations
 	KeyFile string `json:"keyFile,omitempty"`

--- a/pkg/ssh/sshCommand.go
+++ b/pkg/ssh/sshCommand.go
@@ -102,17 +102,12 @@ func (c *HostSSHConfig) ExecuteCmdWithStdinFile(cmd, filePath string) (string, e
 		}
 	}
 
-	// Start a command on our remote session, this should be something that is expecting stdin
-	if err := c.Session.Start(cmd); err != nil {
-		return "", err
-	}
-
 	// get a stdin pipe
 	si, err := c.Session.StdinPipe()
 	if err != nil {
 		return "", err
 	}
-	defer si.Close()
+	//defer si.Close()
 
 	// get a stdout pipe
 	so, err := c.Session.StdoutPipe()
@@ -126,11 +121,18 @@ func (c *HostSSHConfig) ExecuteCmdWithStdinFile(cmd, filePath string) (string, e
 		return "", err
 	}
 
+	// Start a command on our remote session, this should be something that is expecting stdin
+	if err := c.Session.Start(cmd); err != nil {
+		return "", err
+	}
+
 	// do the actual work
 	n, err := io.Copy(si, file)
 	if err != nil {
 		return "", err
 	}
+	// Close the stdin as we've finised transmitting the data
+	si.Close()
 
 	log.Debugf("Copied %d bytes over the stdin pipe", n)
 	// wait for process to finishe


### PR DESCRIPTION
This moves the requirement of local execution and then piping data over another ssh connection. This allows an ssh connection to be established a command to be ran (that waits for some data) followed by the passing of that data over to stdin. 

The main use case is sending a file over ssh to something remote waiting for it (i.e. `docker load`)