### PR TITLE
Can start a local cmd and pipe stdout to the stdin of a remote command

### DIFF
--- a/pkg/parlay/parser.go
+++ b/pkg/parlay/parser.go
@@ -315,7 +315,7 @@ func parallelDeployment(action []types.Action, hosts []ssh.HostSSHConfig) error 
 
 				return err
 			}
-			crs := ssh.ParalellExecute(command, action[y].CommandPipeFile, hosts, action[y].Timeout)
+			crs := ssh.ParalellExecute(command, action[y].CommandPipeFile, action[y].CommandPipeCmd, hosts, action[y].Timeout)
 			var errors bool // This will only be set to true if a command fails
 			for x := range crs {
 				if crs[x].Error != nil {
@@ -396,7 +396,7 @@ func parseAndExecute(a types.Action, h *ssh.HostSSHConfig) ssh.CommandResult {
 		cr.Result = strings.TrimRight(string(b), "\r\n")
 	} else {
 		log.Debugf("Executing command [%s] on host [%s]", command, h.Host)
-		cr = ssh.SingleExecute(command, a.CommandPipeFile, *h, a.Timeout)
+		cr = ssh.SingleExecute(command, a.CommandPipeFile, a.CommandPipeCmd, *h, a.Timeout)
 
 		cr.Result = strings.TrimRight(cr.Result, "\r\n")
 

--- a/pkg/parlay/types/types.go
+++ b/pkg/parlay/types/types.go
@@ -24,7 +24,10 @@ type Action struct {
 	CommandSaveFile  string `json:"commandSaveFile,omitempty"`
 	CommandSaveAsKey string `json:"commandSaveAsKey,omitempty"`
 	CommandSudo      string `json:"commandSudo,omitempty"`
-	CommandPipeFile  string `json:"commandPipeFile,omitempty"`
+
+	// Piping commands, read in a file and send over stdin, or capture stdout from a local command
+	CommandPipeFile string `json:"commandPipeFile,omitempty"`
+	CommandPipeCmd  string `json:"commandPipeCmd,omitempty"`
 
 	// Key operations
 	KeyFile string `json:"keyFile,omitempty"`

--- a/pkg/ssh/sshCommand.go
+++ b/pkg/ssh/sshCommand.go
@@ -5,21 +5,23 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
 )
 
 // SingleExecute - This will execute a command on a single host
-func SingleExecute(cmd, pipefile string, host HostSSHConfig, to int) CommandResult {
+func SingleExecute(cmd, pipefile, pipecmd string, host HostSSHConfig, to int) CommandResult {
 	var configs []HostSSHConfig
 	configs = append(configs, host)
-	result := ParalellExecute(cmd, pipefile, configs, to)
+	result := ParalellExecute(cmd, pipefile, pipecmd, configs, to)
 	return result[0]
 }
 
 //ParalellExecute - This will execute the same command in paralell across multiple hosts
-func ParalellExecute(cmd, pipefile string, hosts []HostSSHConfig, to int) []CommandResult {
+func ParalellExecute(cmd, pipefile, pipecmd string, hosts []HostSSHConfig, to int) []CommandResult {
 	var cmdResults []CommandResult
 	// Run parallel ssh session (max 10)
 	results := make(chan CommandResult, 10)
@@ -43,6 +45,14 @@ func ParalellExecute(cmd, pipefile string, hosts []HostSSHConfig, to int) []Comm
 
 			if pipefile != "" {
 				if text, err := host.ExecuteCmdWithStdinFile(cmd, pipefile); err != nil {
+					// Report any returned values
+					res.Error = err
+					res.Result = text
+				} else {
+					res.Result = text
+				}
+			} else if pipecmd != "" {
+				if text, err := host.ExecuteCmdWithStdinCmd(cmd, pipecmd); err != nil {
 					// Report any returned values
 					res.Error = err
 					res.Result = text
@@ -116,7 +126,9 @@ func (c *HostSSHConfig) ExecuteCmdWithStdinFile(cmd, filePath string) (string, e
 	}
 
 	// open file as an io.reader
-	file, err := os.Open(filePath)
+	// Also resolve the absolute path just incase
+	absPath, _ := filepath.Abs(filePath)
+	file, err := os.Open(absPath)
 	if err != nil {
 		return "", err
 	}
@@ -136,6 +148,75 @@ func (c *HostSSHConfig) ExecuteCmdWithStdinFile(cmd, filePath string) (string, e
 
 	log.Debugf("Copied %d bytes over the stdin pipe", n)
 	// wait for process to finishe
+	if err := c.Session.Wait(); err != nil {
+		return "", err
+	}
+
+	// Read all the data from the bu
+	var b []byte
+	if b, err = ioutil.ReadAll(so); err != nil {
+		return "", err
+
+	}
+	return string(b), nil
+
+}
+
+// ExecuteCmdWithStdinCmd -
+func (c *HostSSHConfig) ExecuteCmdWithStdinCmd(cmd, localCmd string) (string, error) {
+	if c.Session == nil {
+		if _, err := c.StartSession(); err != nil {
+			return "", err
+		}
+	}
+
+	// get a stdin pipe
+	si, err := c.Session.StdinPipe()
+	if err != nil {
+		return "", err
+	}
+
+	// get a stdout pipe
+	so, err := c.Session.StdoutPipe()
+	if err != nil {
+		return "", err
+	}
+
+	// Start a command on our remote session, this should be something that is expecting stdin
+	if err := c.Session.Start(cmd); err != nil {
+		return "", err
+	}
+
+	// Start our local command that should be exposing something through stdout
+	localExecCmd := exec.Command("bash", "-c", localCmd)
+	localso, err := localExecCmd.StdoutPipe()
+	if err != nil {
+		return "", err
+	}
+	err = localExecCmd.Start()
+	if err != nil {
+		return "", err
+	}
+
+	// do the actual work
+	n, err := io.Copy(si, localso)
+	if err != nil {
+		return "", err
+	}
+
+	// Close the stdin/stdout as we've finised transmitting the data
+	si.Close()
+	localso.Close()
+
+	log.Debugf("Copied %d bytes over the stdin pipe", n)
+
+	// Wait for local process to finish
+	err = localExecCmd.Wait()
+	if err != nil {
+		return "", err
+	}
+
+	// wait for remote process to finish
 	if err := c.Session.Wait(); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
The docker plugin has been updated to make use of this functionality.. 

But this allows the following sorts of functionality:
```
                                {
                                        "name": "SSH TEST",
                                        "type": "command",
                                        "commandPipeCmd": "sudo docker save gitlab/gitlab-ce:latest",
                                        "commandSudo": "root",
                                        "command": "docker load"
                                }
```