### PR TITLE
Move to an array of images to be exported

### DIFF
--- a/pkg/ssh/sshCommand.go
+++ b/pkg/ssh/sshCommand.go
@@ -117,7 +117,6 @@ func (c *HostSSHConfig) ExecuteCmdWithStdinFile(cmd, filePath string) (string, e
 	if err != nil {
 		return "", err
 	}
-	//defer si.Close()
 
 	// get a stdout pipe
 	so, err := c.Session.StdoutPipe()
@@ -225,7 +224,6 @@ func (c *HostSSHConfig) ExecuteCmdWithStdinCmd(cmd, localCmd string) (string, er
 	var b []byte
 	if b, err = ioutil.ReadAll(so); err != nil {
 		return "", err
-
 	}
 	return string(b), nil
 

--- a/plugin/docker/docker.go
+++ b/plugin/docker/docker.go
@@ -10,20 +10,20 @@ import (
 const pluginInfo = `This plugin is used to managed docker automation`
 
 type image struct {
+
 	// Image details
 	ImageNames []string `json:"imageName"`
 	ImageFiles []string `json:"imageFile"`
-	//ImageRetag         string   `json:"imageRetag"`
-	//DockerUser         string   `json:"username"`
+
 	DockerLocalSudo  bool `json:"localSudo"`
 	DockerRemoteSudo bool `json:"remoteSudo"`
-	//DisableSSHSecurity bool     `json:"disableSSHSecurity"`
 }
 
 type tag struct {
-	// Image tag effectively takes an image and will retag it
-	SourceName string `json:"sourceName"`
-	TargetName string `json:"targetName"`
+
+	// A list of sources and target tags
+	SourceNames []string `json:"sourceNames,omitempty"`
+	TargetNames []string `json:"targetNames,omitempty"`
 
 	// These two fields are used to change out a tag (e.g. version number) or the repository itself
 	TargetTag  string `json:"imageTag,omitempty"`
@@ -71,8 +71,8 @@ func ParlayUsage(action string) (raw json.RawMessage, err error) {
 		return json.Marshal(a)
 	case "docker/tag":
 		a := tag{
-			SourceName: "gcr.io/my_image:latest",
-			TargetName: "internal_repo/my_image:1.0",
+			SourceNames: []string{"gcr.io/my_image:latest"},
+			TargetNames: []string{"internal_repo/my_image:1.0"},
 		}
 		// In order to turn a struct into an map[string]interface we need to turn it into JSON
 
@@ -101,7 +101,7 @@ func ParlayExec(action, host string, raw json.RawMessage) (actions []types.Actio
 		var t tag
 		// Unmarshall the JSON into the struct
 		err = json.Unmarshal(raw, &t)
-		return t.generateTagActions(host), err
+		return t.generateTagActions(host)
 	default:
 		return
 	}

--- a/plugin/docker/docker_actions.go
+++ b/plugin/docker/docker_actions.go
@@ -54,31 +54,27 @@ func (i *image) generateImageActions(host string) []types.Action {
 		}
 	}
 
-	// If the downloaded tarball contains a bizarre repo/tag then we can rename/(retag) the image locally
-	// if i.ImageRetag != "" && i.ImageName != "" {
-	// 	a = types.Action{
-	// 		ActionType:  "command",
-	// 		Command:     fmt.Sprintf("%s tag %s %s", dockerRemoteString, i.ImageName, i.ImageRetag),
-	// 		CommandSudo: "root",
-	// 		Name:        fmt.Sprintf("Retag %s --> %s", i.ImageName, i.ImageRetag),
-	// 	}
-	// 	generatedActions = append(generatedActions, a)
-	// }
 	return generatedActions
 }
 
-func (t *tag) generateTagActions(host string) []types.Action {
+func (t *tag) generateTagActions(host string) ([]types.Action, error) {
+
+	if len(t.SourceNames) != len(t.TargetNames) {
+		return nil, fmt.Errorf("The number of images to retag doesn't match the number of tags")
+	}
 	var generatedActions []types.Action
 
-	// Generate the retag action
-	var a = types.Action{
-		ActionType:  "command",
-		Command:     fmt.Sprintf("sudo docker tag %s %s", t.SourceName, t.TargetName),
-		CommandSudo: "root",
-		Name:        fmt.Sprintf("Retag %s --> %s", t.SourceName, t.TargetName),
+	// Iterate through all of the images and create retagging actions
+	for y := range t.SourceNames {
+		// Generate the retag action
+		var a = types.Action{
+			ActionType:  "command",
+			Command:     fmt.Sprintf("sudo docker tag %s %s", t.SourceNames[y], t.TargetNames[y]),
+			CommandSudo: "root",
+			Name:        fmt.Sprintf("Retag %s --> %s", t.SourceNames[y], t.TargetNames[y]),
+		}
+
+		generatedActions = append(generatedActions, a)
 	}
-
-	generatedActions = append(generatedActions, a)
-
-	return generatedActions
+	return generatedActions, nil
 }


### PR DESCRIPTION
Moving to an array allows a simpler action that defines a number of images in a single execution.

```
                {
                    "name": "Push calico images for workers",
                    "type": "docker/image",
                    "timeout": 0,
                    "plugin": {
                        "imageName": ["calico/node:v3.5.1", "calico/cni:v3.5.1"],
                        "localSudo" :true, 
                        "remoteSudo": true
                    }
                },
```