### PR TITLE
Big re-write of the Booting structure

### DIFF
--- a/cmd/initialisation.go
+++ b/cmd/initialisation.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/plunder-app/plunder/pkg/bootstraps"
 	"github.com/plunder-app/plunder/pkg/parlay"
 	"github.com/plunder-app/plunder/pkg/parlay/types"
+	"github.com/plunder-app/plunder/pkg/server"
 	"github.com/plunder-app/plunder/pkg/utils"
 
 	log "github.com/Sirupsen/logrus"
@@ -58,8 +58,8 @@ var plunderDeploymentConfig = &cobra.Command{
 	Short: "Initialise a server configuration",
 	Run: func(cmd *cobra.Command, args []string) {
 		log.SetLevel(log.Level(logLevel))
-		var configuration bootstraps.DeploymentConfigurationFile
-		configuration.Deployments = append(configuration.Deployments, bootstraps.DeploymentConfigurations{})
+		var configuration server.DeploymentConfigurationFile
+		configuration.Deployments = append(configuration.Deployments, server.DeploymentConfigurations{})
 		// Indent (or pretty-print) the configuration output
 		b, err := json.MarshalIndent(configuration, "", "\t")
 		if err != nil {

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -5,8 +5,6 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/plunder-app/plunder/pkg/bootstraps"
-
 	"github.com/plunder-app/plunder/pkg/utils"
 
 	"github.com/plunder-app/plunder/pkg/server"
@@ -70,7 +68,7 @@ var PlunderServer = &cobra.Command{
 	Short: "Start Plunder Services",
 	Run: func(cmd *cobra.Command, args []string) {
 		log.SetLevel(log.Level(logLevel))
-
+		var deployment []byte
 		// If deploymentPath is not blank then the flag has been used
 		if *deploymentPath != "" {
 			if *anyboot == true {
@@ -78,11 +76,7 @@ var PlunderServer = &cobra.Command{
 			}
 			log.Infof("Reading deployment configuration from [%s]", *deploymentPath)
 			if _, err := os.Stat(*deploymentPath); !os.IsNotExist(err) {
-				deployment, err := ioutil.ReadFile(*deploymentPath)
-				if err != nil {
-					log.Fatalf("%v", err)
-				}
-				err = bootstraps.UpdateConfiguration(deployment)
+				deployment, err = ioutil.ReadFile(*deploymentPath)
 				if err != nil {
 					log.Fatalf("%v", err)
 				}
@@ -90,7 +84,7 @@ var PlunderServer = &cobra.Command{
 		}
 
 		if *anyboot == true {
-			bootstraps.AnyBoot = true
+			server.AnyBoot = true
 		}
 
 		// If configPath is not blank then the flag has been used
@@ -122,7 +116,7 @@ var PlunderServer = &cobra.Command{
 			log.Fatalln("At least one available lease is required")
 		}
 
-		controller.StartServices()
+		controller.StartServices(deployment)
 		return
 	},
 }

--- a/pkg/server/kickstart.go
+++ b/pkg/server/kickstart.go
@@ -1,9 +1,9 @@
-package bootstraps
+package server
 
 import "fmt"
 
 // This initial template will be modifiable based upon the build requirements
-const kickstart = `
+const kickstartFile = `
 install
 cdrom
 lang en_US.UTF-8
@@ -166,6 +166,6 @@ yum clean all
 `
 
 // BuildKickStartConfig - Creates a new presseed configuration using the passed data
-func (config *ServerConfig) BuildKickStartConfig() string {
+func (config *HostConfig) BuildKickStartConfig() string {
 	return fmt.Sprintf("%s%s%s%s%s%s", preseed, preseedDisk, preseedNet, preseedPkg, preseedUsers, preseedCmd)
 }

--- a/pkg/server/preseed.go
+++ b/pkg/server/preseed.go
@@ -1,4 +1,4 @@
-package bootstraps
+package server
 
 import (
 	"fmt"
@@ -7,7 +7,7 @@ import (
 )
 
 // Preseed const, this is the basis for the configuration that will be modified per use-case
-const preseed = `
+const preseedHead = `
 # Force debconf priority to critical.
 debconf debconf/priority select critical
 # Override default frontend to Noninteractive
@@ -180,7 +180,7 @@ d-i preseed/late_command string \
 `
 
 //BuildPreeSeedConfig - Creates a new presseed configuration using the passed data
-func (config *ServerConfig) BuildPreeSeedConfig() string {
+func (config *HostConfig) BuildPreeSeedConfig() string {
 
 	var key string
 	var err error
@@ -206,5 +206,5 @@ func (config *ServerConfig) BuildPreeSeedConfig() string {
 	parsedPkg := fmt.Sprintf(preseedPkg, config.RepositoryAddress, config.MirrorDirectory, config.Packages)
 	parsedCmd := fmt.Sprintf(preseedCmd, key)
 	parsedUsr := fmt.Sprintf(preseedUsers, config.Username, config.Username, config.Password, config.Password)
-	return fmt.Sprintf("%s%s%s%s%s%s", preseed, parsedDisk, parsedNet, parsedPkg, parsedUsr, parsedCmd)
+	return fmt.Sprintf("%s%s%s%s%s%s", preseedHead, parsedDisk, parsedNet, parsedPkg, parsedUsr, parsedCmd)
 }

--- a/pkg/server/serve_dhcp.go
+++ b/pkg/server/serve_dhcp.go
@@ -1,13 +1,14 @@
 package server
 
 import (
+	"fmt"
 	"math/rand"
 	"net"
+	"strings"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
 	dhcp "github.com/krolaw/dhcp4"
-	"github.com/plunder-app/plunder/pkg/bootstraps"
 )
 
 type lease struct {
@@ -47,7 +48,7 @@ func (h *DHCPSettings) ServeDHCP(p dhcp.Packet, msgType dhcp.MessageType, option
 		// Reply should have the configuration details in for iPXE to boot from
 		if string(options[77]) != "" {
 			if string(options[77]) == "iPXE" {
-				deploymentType := bootstraps.FindDeployment(mac)
+				deploymentType := FindDeployment(mac)
 				// If this mac address has no deployment attached then reboot IPXE
 				if deploymentType == "" {
 					log.Warnf("Mac address[%s] is unknown, not returning an address", mac)
@@ -55,7 +56,14 @@ func (h *DHCPSettings) ServeDHCP(p dhcp.Packet, msgType dhcp.MessageType, option
 				}
 				// Assign the deployment boot script
 				log.Infof("Mac address [%s] is assigned a [%s] deployment type", mac, deploymentType)
-				h.Options[67] = []byte("http://" + h.IP.String() + "/" + deploymentType + ".ipxe")
+				// Convert the : in the mac address to dashes to make life easier
+				dashMac := strings.Replace(mac, ":", "-", -1)
+				// if an entry doesnt exist then drop it to a default type, if not then it has its own specific
+				if httpPaths[fmt.Sprintf("%s.ipxe", dashMac)] == "" {
+					h.Options[67] = []byte("http://" + h.IP.String() + "/" + deploymentType + ".ipxe")
+				} else {
+					h.Options[67] = []byte("http://" + h.IP.String() + "/" + dashMac + ".ipxe")
+				}
 
 			}
 		}

--- a/pkg/ssh/sshImport.go
+++ b/pkg/ssh/sshImport.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/plunder-app/plunder/pkg/bootstraps"
+	"github.com/plunder-app/plunder/pkg/server"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -18,7 +18,7 @@ var cachedGlobalKey ssh.AuthMethod
 // ImportHostsFromDeployment - This will import a list of hosts from a file
 func ImportHostsFromDeployment(configFile string) error {
 
-	var deployment bootstraps.DeploymentConfigurationFile
+	var deployment server.DeploymentConfigurationFile
 	var err error
 	// Check the actual path from the string
 	if _, err := os.Stat(configFile); !os.IsNotExist(err) {


### PR DESCRIPTION
When a configuration is loaded, plunder will build a set of map[string]string that will be also "mapped" to a url.
`url` => `key` -> `value`
"/aa-bb-cc-dd-ee.ipxe" => [" /aa-bb-cc-dd-ee.ipxe"] -> `ipxe configuration`

This allows dynamic updating and an API front end to modify boot configurations, also no files other than the config need to exist on disk.

@mauilion 