### PR TITLE
Swap is commented out

### DIFF
--- a/pkg/server/preseed.go
+++ b/pkg/server/preseed.go
@@ -176,7 +176,8 @@ d-i preseed/late_command string \
     in-target mkdir -p /home/ubuntu/.ssh; \
     in-target /bin/sh -c "echo '%s' >> /home/ubuntu/.ssh/authorized_keys"; \
     in-target chown -R ubuntu:ubuntu /home/ubuntu/; \
-	in-target chmod -R go-rwx /home/ubuntu/.ssh/authorized_keys;
+	in-target chmod -R go-rwx /home/ubuntu/.ssh/authorized_keys; \
+	in-target sudo sed -i '/ swap / s/^/#/' /etc/fstab
 `
 
 //BuildPreeSeedConfig - Creates a new presseed configuration using the passed data


### PR DESCRIPTION
The preseed configuration will not create a swap partition, however in the newer release of Ubuntu 18.04 a swapfile is added and identified in /etc/fstab, this change will ensure it's commented out as part of the OS build