### PR TITLE
Will now import the current user/default keys and improved debugging

### DIFF
--- a/pkg/ssh/sshClient.go
+++ b/pkg/ssh/sshClient.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	log "github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -15,7 +16,8 @@ func (c *HostSSHConfig) StartConnection() (*ssh.Client, error) {
 	if !strings.ContainsAny(c.Host, ":") {
 		host = host + ":22"
 	}
-	//log.Printf("%v", c)
+
+	log.Debugf("Beginning connection to [%s] with user [%s]", c.Host, c.User)
 	c.Connection, err = ssh.Dial("tcp", host, c.ClientConfig)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
If a key isn't specified on command line or in a deployment config then it will default to the current user/local keys. It will also print out more debug information to make it clearer what is happening.