### PR TITLE
HUUUGE re-write to enable API driven deployments

### DIFF
--- a/cmd/initialisation.go
+++ b/cmd/initialisation.go
@@ -41,9 +41,15 @@ var plunderServerConfig = &cobra.Command{
 	Short: "Initialise a plunder configuration",
 	Run: func(cmd *cobra.Command, args []string) {
 		log.SetLevel(log.Level(logLevel))
-
 		// Indent (or pretty-print) the configuration output
-		b, err := json.MarshalIndent(controller, "", "\t")
+		bc := &server.BootConfig{
+			Kernel:     "/kernelPath",
+			Initrd:     "/initPath",
+			Cmdline:    "cmd=options",
+			ConfigName: "default",
+		}
+		server.Controller.BootConfigs = append(server.Controller.BootConfigs, *bc)
+		b, err := json.MarshalIndent(server.Controller, "", "\t")
 		if err != nil {
 			log.Fatalf("%v", err)
 		}
@@ -59,7 +65,7 @@ var plunderDeploymentConfig = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		log.SetLevel(log.Level(logLevel))
 		var configuration server.DeploymentConfigurationFile
-		configuration.Deployments = append(configuration.Deployments, server.DeploymentConfigurations{})
+		configuration.Configs = append(configuration.Configs, server.DeploymentConfig{})
 		// Indent (or pretty-print) the configuration output
 		b, err := json.MarshalIndent(configuration, "", "\t")
 		if err != nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1,0 +1,39 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/ghodss/yaml"
+)
+
+// This is needed by other functions to build strings
+var httpAddress string
+
+// Controller contains all the "current" settings for booting servers
+var Controller BootController
+
+// Deployments - contains an accessible "current" configuration for all deployments
+var Deployments DeploymentConfigurationFile
+
+// ParseControllerFile will read in a byte array and attempt to parse it as yaml or json
+func ParseControllerFile(b []byte) error {
+
+	jsonBytes, err := yaml.YAMLToJSON(b)
+	if err == nil {
+		// If there were no errors then the YAML => JSON was successful, no attempt to unmarshall
+		err = json.Unmarshal(jsonBytes, &Controller)
+		if err != nil {
+			return fmt.Errorf("Unable to parse configuration as either yaml or json")
+		}
+
+	} else {
+		// Couldn't parse the yaml to JSON
+		// Attempt to parse it as JSON
+		err = json.Unmarshal(b, &Controller)
+		if err != nil {
+			return fmt.Errorf("Unable to parse configuration as either yaml or json")
+		}
+	}
+	return nil
+}

--- a/pkg/server/templatePreseed.go
+++ b/pkg/server/templatePreseed.go
@@ -186,9 +186,6 @@ func (config *HostConfig) BuildPreeSeedConfig() string {
 	var key string
 	var err error
 
-	// This will populate anything missing from the global configuration
-	config.PopulateConfiguration()
-
 	if config.SSHKeyPath != "" {
 		key, err = config.ReadKeyFromFile(config.SSHKeyPath)
 		if err != nil {

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -1,10 +1,8 @@
 package server
 
-// This is needed by other functions to build strings
-var httpAddress string
+// TYPE DEFINITIONS Below
 
 // BootController contains the settings that define how the remote boot will
-// behave
 type BootController struct {
 	AdapterName *string `json:"adapter"` // A physical adapter to bind to e.g. en0, eth0
 
@@ -23,7 +21,7 @@ type BootController struct {
 	PXEFileName *string `json:"pxePath"` // undionly.kpxe
 
 	// Boot Configuration
-	BootConfigs []bootConfig `json:"bootConfigs"` // Array of kernel configurations
+	BootConfigs []BootConfig `json:"bootConfigs"` // Array of kernel configurations
 
 	handler *DHCPSettings
 }
@@ -36,34 +34,27 @@ type dhcpConfig struct {
 	DHCPDNS          *string `json:"nameserverDHCP"` // DNS server to advertise
 }
 
-type bootConfig struct {
-	ConfigName *string `json:"configName"`
-	// iPXE file settings - exported
-	Kernel  *string `json:"kernelPath"`
-	Initrd  *string `json:"initrdPath"`
-	Cmdline *string `json:"cmdline"`
-}
-
-// DeploymentConfig - contains an accessible "current" configuration
-var DeploymentConfig DeploymentConfigurationFile
-
-// DeploymentConfigurationFile - The bootstraps.Configs is used by other packages to manage use case for Mac addresses
-type DeploymentConfigurationFile struct {
-	GlobalServerConfig HostConfig                 `json:"globalConfig"`
-	Deployments        []DeploymentConfigurations `json:"deployments"`
-}
-
-// DeploymentConfigurations - is used to parse the files containing all server configurations
-type DeploymentConfigurations struct {
-	MAC string `json:"mac"`
-
+// BootConfig defines a named configuration for booting
+type BootConfig struct {
+	ConfigName string `json:"configName"`
 	// iPXE file settings - exported
 	Kernel  string `json:"kernelPath"`
 	Initrd  string `json:"initrdPath"`
 	Cmdline string `json:"cmdline"`
+}
 
-	Deployment string     `json:"deployment"` // Either preseed or kickstart
-	Config     HostConfig `json:"config"`
+// DeploymentConfigurationFile - The bootstraps.Configs is used by other packages to manage use case for Mac addresses
+type DeploymentConfigurationFile struct {
+	GlobalServerConfig HostConfig         `json:"globalConfig"`
+	Configs            []DeploymentConfig `json:"deployments"`
+}
+
+// DeploymentConfig - is used to parse the files containing all server configurations
+type DeploymentConfig struct {
+	MAC        string     `json:"mac"`
+	ConfigName string     `json:"bootConfigName,omitempty"` // To be discovered in the controller BootConfig array
+	ConfigBoot BootConfig `json:"bootConfig,omitempty"`     // Array of kernel configurations
+	ConfigHost HostConfig `json:"config"`
 }
 
 // HostConfig - Defines how a server will be configured by plunder

--- a/pkg/ssh/sshImport.go
+++ b/pkg/ssh/sshImport.go
@@ -89,7 +89,7 @@ func ImportHostsFromDeployment(config []byte) error {
 		return err
 	}
 
-	if len(deployment.Deployments) == 0 {
+	if len(deployment.Configs) == 0 {
 		return fmt.Errorf("No deployment configurations found")
 	}
 
@@ -112,13 +112,13 @@ func ImportHostsFromDeployment(config []byte) error {
 	}
 
 	// Parse the deployments
-	for i := range deployment.Deployments {
+	for i := range deployment.Configs {
 		var sshHost HostSSHConfig
 
-		sshHost.Host = deployment.Deployments[i].Config.IPAddress
+		sshHost.Host = deployment.Configs[i].ConfigHost.IPAddress
 
-		if deployment.Deployments[i].Config.Username != "" {
-			sshHost.User = deployment.Deployments[i].Config.Username
+		if deployment.Configs[i].ConfigHost.Username != "" {
+			sshHost.User = deployment.Configs[i].ConfigHost.Username
 		} else {
 			sshHost.User = deployment.GlobalServerConfig.Username
 		}
@@ -126,8 +126,8 @@ func ImportHostsFromDeployment(config []byte) error {
 		// Find additional keys that may exist in the same location
 		var keys []ssh.AuthMethod
 
-		if deployment.Deployments[i].Config.SSHKeyPath != "" {
-			key, err := findPrivateKey(deployment.Deployments[i].Config.SSHKeyPath)
+		if deployment.Configs[i].ConfigHost.SSHKeyPath != "" {
+			key, err := findPrivateKey(deployment.Configs[i].ConfigHost.SSHKeyPath)
 			if err != nil {
 				return err
 			}
@@ -136,7 +136,7 @@ func ImportHostsFromDeployment(config []byte) error {
 			if cachedGlobalKey != nil {
 				keys = append(keys, cachedGlobalKey)
 			} else {
-				return fmt.Errorf("Host [%s] has no key specified", deployment.Deployments[i].Config.IPAddress)
+				return fmt.Errorf("Host [%s] has no key specified", deployment.Configs[i].ConfigHost.IPAddress)
 			}
 		}
 		sshHost.ClientConfig = &ssh.ClientConfig{User: sshHost.User, Auth: keys, HostKeyCallback: ssh.InsecureIgnoreHostKey()}

--- a/pkg/utils/ipxe.go
+++ b/pkg/utils/ipxe.go
@@ -41,7 +41,7 @@ reboot
 }
 
 // IPXEPreeseed - This will build an iPXE boot script for Debian/Ubuntu
-func IPXEPreeseed(webserverAddress string, kernel string, initrd string, cmdline string) string {
+func IPXEPreeseed(webserverAddress,kernel , initrd , cmdline string) string{
 	script := `
 kernel http://%s/%s auto=true url=http://%s/${mac:hexhyp}.cfg priority=critical %s netcfg/choose_interface=${netX/mac}
 initrd http://%s/%s
@@ -54,7 +54,7 @@ boot
 }
 
 // IPXEKickstart - This will build an iPXE boot script for RHEL/CentOS
-func IPXEKickstart(webserverAddress string, kernel string, initrd string, cmdline string) string {
+func IPXEKickstart(webserverAddress, kernel , initrd , cmdline string) string{
 	script := `
 kernel http://%s/%s auto=true url=http://%s/${mac:hexhyp}.cfg priority=critical %s 
 initrd http://%s/%s
@@ -67,7 +67,7 @@ boot
 }
 
 // IPXEAnyBoot - This will build an iPXE boot script for anything wanting to PXE boot
-func IPXEAnyBoot(webserverAddress string, kernel string, initrd string, cmdline string) string {
+func IPXEAnyBoot(webserverAddress string, kernel , initrd , cmdline string) string{
 	script := `
 kernel http://%s/%s auto=true url=http://%s/${mac:hexhyp}.cfg %s 
 initrd http://%s/%s


### PR DESCRIPTION
Other than a few UI changes, the majority of changes are internal:

- Server config now has DHCPServer config as seperate object
- Server config takes multiple labelled kernel/initrd configs that a deployment can references

BUG in global preference adoption still.