### PR TITLE
Shows in example to reference controller PXE configurations

### DIFF
--- a/cmd/initialisation.go
+++ b/cmd/initialisation.go
@@ -88,6 +88,7 @@ var plunderDeploymentConfig = &cobra.Command{
 		hostDeployConfig := server.DeploymentConfig{
 			MAC:        "00:11:22:33:44:55",
 			ConfigHost: hostConfig,
+			ConfigName: "default",
 		}
 
 		configuration := &server.DeploymentConfigurationFile{


### PR DESCRIPTION
Adds a `bootConfig` to the example output.