### PR TITLE
Dockerfile to build iPXE with comboot support

### DIFF
--- a/hack/comboot_ipxe/Dockerfile
+++ b/hack/comboot_ipxe/Dockerfile
@@ -1,0 +1,8 @@
+FROM gcc:latest AS IPXE_BUILD
+RUN git clone git://git.ipxe.org/ipxe.git
+RUN sed '/COMBOOT/s/\/\///g' ipxe/src/config/general.h
+WORKDIR /ipxe/src/
+RUN make bin/undionly.kpxe 
+
+FROM scratch
+COPY --from=IPXE_BUILD /ipxe/src/bin/undionly.kpxe .


### PR DESCRIPTION
This Dockerfile will follow all of the steps to build a `undionly.kpxe` that supports legacy COMBOOT support, which is being sued by vSphere ...