### PR TITLE
This adds a seperate APU for updating the global configuration

### DIFF
--- a/pkg/apiserver/handlersDeployment.go
+++ b/pkg/apiserver/handlersDeployment.go
@@ -83,15 +83,29 @@ func postDeployment(w http.ResponseWriter, r *http.Request) {
 // Retrieve a specific plunder deployment configuration
 func updateDeployment(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
+	var rsp response
 
 	// Find the deployment ID
 	id := mux.Vars(r)["id"]
+
+	// Are we updating the deployment "global"
+	if id == "global" {
+		if b, err := ioutil.ReadAll(r.Body); err == nil {
+			err := services.UpdateGlobalDeploymentConfig(b)
+	
+			if err != nil {
+				rsp.FriendlyError = "Error updating Global Configuration"
+				rsp.Error = err.Error()
+				rsp.Response = nil
+				json.NewEncoder(w).Encode(rsp)
+			}
+		}
+	} else {
 	// We need to revert the mac address back to the correct format (dashes back to colons)
 	mac := strings.Replace(id, "-", ":", -1)
 
 	if b, err := ioutil.ReadAll(r.Body); err == nil {
 		err := services.UpdateDeployment(mac, b)
-		var rsp response
 
 		if err != nil {
 			rsp.FriendlyError = "Error updating Deployment Configuration"
@@ -100,6 +114,7 @@ func updateDeployment(w http.ResponseWriter, r *http.Request) {
 			json.NewEncoder(w).Encode(rsp)
 		}
 	}
+}
 }
 
 // Retrieve a specific plunder deployment configuration

--- a/pkg/services/deployments.go
+++ b/pkg/services/deployments.go
@@ -214,6 +214,18 @@ func DeleteDeployment(macAddress string, rawDeployment []byte) error {
 
 }
 
+// UpdateGlobalDeploymentConfig - This allows updating of the global configuration independently
+func UpdateGlobalDeploymentConfig(rawDeployment []byte) error {
+	var globalDeploymentConfig HostConfig
+	err := json.Unmarshal(rawDeployment, &globalDeploymentConfig)
+	if err != nil {
+		return fmt.Errorf("Unable to parse deployment configuration")
+	}
+	// Update the deployments with the new configuration
+	Deployments.GlobalServerConfig = globalDeploymentConfig
+	return nil
+}
+
 //FindDeploymentConfigFromMac - this will return the deployment configuration, allowing the DHCP server to return the correct DHCP options
 func FindDeploymentConfigFromMac(mac string) string {
 


### PR DESCRIPTION
A POST to `/deployment/global` will update the global configuration separately. 