### PR TITLE
Added capabilities to generate full server-client configs

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -15,7 +15,7 @@ import (
 //var controller server.BootController
 var dhcpSettings services.DHCPSettings
 
-var gateway, dns, startAddress, configPath, deploymentPath, defaultKernel, defaultInitrd, defaultCmdLine *string
+var apiServerPath, gateway, dns, startAddress, configPath, deploymentPath, defaultKernel, defaultInitrd, defaultCmdLine *string
 
 var leasecount, port *int
 
@@ -55,6 +55,7 @@ func init() {
 	// API Server configuration
 	port = PlunderServer.Flags().IntP("port", "p", 60443, "Port that the Plunder API server will listen on")
 	insecure = PlunderServer.Flags().BoolP("insecure", "i", false, "Start the Plunder API server without encryption")
+	apiServerPath = PlunderServer.Flags().String("path", ".plunderserver.yaml", "Path to configuration for the API Server")
 
 	plunderCmd.AddCommand(PlunderServer)
 }
@@ -123,7 +124,7 @@ var PlunderServer = &cobra.Command{
 
 		// Run the API server in a seperate go routine
 		go func() {
-			err := apiserver.Server(*port, *insecure)
+			err := apiserver.Server(*apiServerPath, *port, *insecure)
 			if err != nil {
 				log.Fatalf("%v", err)
 			}

--- a/pkg/apiserver/config.go
+++ b/pkg/apiserver/config.go
@@ -1,0 +1,157 @@
+package apiserver
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/url"
+
+	"github.com/ghodss/yaml"
+)
+
+// ClientConfig is the structure of an expected configuration for pldctl
+type ClientConfig struct {
+	Address    string `json:"address,omitempty"`
+	Port       int    `json:"port"`
+	ClientCert string `json:"cert"`
+}
+
+// ServerConfig is the structure of an expected configuration for pldctl
+type ServerConfig struct {
+	ClientConfig
+	ServerKey string `json:"key"`
+}
+
+//OpenClientConfig will open and parse a Plunder server configuration file
+func OpenClientConfig(path string) (*ClientConfig, error) {
+	var c ClientConfig
+	// Create a CA certificate pool and add cert.pem to it
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	jsonBytes, err := yaml.YAMLToJSON(b)
+	if err == nil {
+		// If there were no errors then the YAML => JSON was successful, no attempt to unmarshall
+		err = json.Unmarshal(jsonBytes, &c)
+		if err != nil {
+			return nil, fmt.Errorf("Unable to parse configuration as either yaml or json")
+		}
+	} else {
+		// Couldn't parse the yaml to JSON
+		// Attempt to parse it as JSON
+		err = json.Unmarshal(b, &c)
+		if err != nil {
+			return nil, fmt.Errorf("Unable to parse configuration as either yaml or json")
+		}
+	}
+	return &c, nil
+}
+
+//OpenServerConfig will open and parse a Plunder server configuration file
+func OpenServerConfig(path string) (*ServerConfig, error) {
+	var s ServerConfig
+	// Create a CA certificate pool and add cert.pem to it
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	jsonBytes, err := yaml.YAMLToJSON(b)
+	if err == nil {
+		// If there were no errors then the YAML => JSON was successful, no attempt to unmarshall
+		err = json.Unmarshal(jsonBytes, &s)
+		if err != nil {
+			return nil, fmt.Errorf("Unable to parse configuration as either yaml or json")
+		}
+	} else {
+		// Couldn't parse the yaml to JSON
+		// Attempt to parse it as JSON
+		err = json.Unmarshal(b, &s)
+		if err != nil {
+			return nil, fmt.Errorf("Unable to parse configuration as either yaml or json")
+		}
+	}
+	return &s, nil
+}
+
+// WriteServerConfig - will write out the server configuration for the API Server
+func WriteServerConfig(path, hostname, address string, port int, cert, key []byte) error {
+	var s ServerConfig
+
+	// base64 the certificates
+	encodedKey := base64.StdEncoding.EncodeToString(key)
+	encodedCert := base64.StdEncoding.EncodeToString(cert)
+
+	// Add the encoded certificates to the struct
+	s.ClientCert = encodedCert
+	s.ServerKey = encodedKey
+
+	// Add the port for automated startup
+	s.Port = port
+
+	// Marshall to yaml
+	b, err := yaml.Marshal(s)
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(path, b, 0600)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// WriteClientConfig - will write out the server configuration for the API Server
+func WriteClientConfig(path, address string, s *ServerConfig) error {
+	var c ClientConfig
+
+	// Add the encoded certificates to the struct
+	c.ClientCert = s.ClientCert
+
+	// Add the host information for automated startup
+	c.Port = s.Port
+	c.Address = address
+
+	// Marshall client configuration to yaml
+	b, err := yaml.Marshal(c)
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(path, b, 0600)
+	if err != nil {
+		return err
+	}
+	return nil
+
+}
+
+//GetServerAddressURL will retrieve a parsed URL
+func (c *ClientConfig) GetServerAddressURL() *url.URL {
+	var plunderURL url.URL
+	plunderURL.Scheme = "https"
+	// Build a url
+	plunderURL.Host = fmt.Sprintf("%s:%d", c.Address, +c.Port)
+	return &plunderURL
+}
+
+func retrieveCert(cert string) ([]byte, error) {
+	return base64.StdEncoding.DecodeString(cert)
+}
+
+// RetrieveKey will decode the base64 certificate
+func (s *ServerConfig) RetrieveKey() ([]byte, error) {
+	return retrieveCert(s.ServerKey)
+}
+
+// RetrieveClientCert will decode the base64 certificate
+func (s *ServerConfig) RetrieveClientCert() ([]byte, error) {
+	return retrieveCert(s.ClientCert)
+}
+
+// RetrieveClientCert will decode the base64 certificate
+func (c *ClientConfig) RetrieveClientCert() ([]byte, error) {
+	return retrieveCert(c.ClientCert)
+}

--- a/pkg/apiserver/server.go
+++ b/pkg/apiserver/server.go
@@ -1,20 +1,52 @@
 package apiserver
 
 import (
+	"crypto/tls"
 	"fmt"
 	"net/http"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 )
 
-//Server -
-func Server(port int, insecure bool) error {
+//Server - will parse a configuration file and passed variables and start the API Server
+func Server(path string, port int, insecure bool) error {
+	conf, err := OpenServerConfig(path)
+	if err != nil {
+		log.Warnln(err)
+		if insecure == false {
+			log.Warningln("Secure server enabled, but no certificates have been loaded [no communication to API server is possible]")
+		}
+		// Create a blank server config as one wont be returned by the above OpenFile
+		conf = &ServerConfig{}
+	}
+	if port != 0 {
+		conf.Port = port
+	}
+
 	e := setAPIEndpoints()
-	log.Infof("Starting API server on port %d", port)
-	var err error
-	address := fmt.Sprintf(":%d", port)
+	log.Infof("Starting API server on port %d", conf.Port)
+	address := fmt.Sprintf(":%d", conf.Port)
 	if insecure == false {
-		err = http.ListenAndServeTLS(address, "plunder.pem", "plunder.key", e)
+		cert, err := conf.RetrieveClientCert()
+		if err != nil {
+			return err
+		}
+		key, err := conf.RetrieveKey()
+		if err != nil {
+			return err
+		}
+		certPair, err := tls.X509KeyPair(cert, key)
+		cfg := &tls.Config{Certificates: []tls.Certificate{certPair}}
+		srv := &http.Server{
+			TLSConfig:    cfg,
+			ReadTimeout:  time.Minute,
+			WriteTimeout: time.Minute,
+			Addr:         address,
+			Handler:      e,
+		}
+		err = srv.ListenAndServeTLS("", "")
+
 	} else {
 		err = http.ListenAndServe(address, e)
 	}

--- a/pkg/certs/certs.go
+++ b/pkg/certs/certs.go
@@ -145,3 +145,13 @@ func WritePemToFile(path string) error {
 
 	return nil
 }
+
+// GetKey - will return the []byte of the key
+func GetKey() []byte {
+	return keyData
+}
+
+// GetPem - will return the []byte of the key
+func GetPem() []byte {
+	return pemData
+}


### PR DESCRIPTION
This adds the following:
- `plunder config apiserver server` - Generates an api server key pair and config
- `plunder config apiserver client` - Generates a client config yaml

All the above have base64 certs embedded and given correct perms, also fixes to `plunder server` that will look for the apiserver config.