### PR TITLE
Exposes DHCP information through the apiserver

### DIFF
--- a/pkg/apiserver/endpoints.go
+++ b/pkg/apiserver/endpoints.go
@@ -23,13 +23,18 @@ func DeploymentAPIPath() string {
 	return "/deployment"
 }
 
+//DHCPAPIPath returns the URI that is used to interact with the plunder Configuration API
+func DHCPAPIPath() string {
+	return "/dhcp"
+}
+
 // setAPIEndpoints defines all of the API end points for Plunder
 func setAPIEndpoints() *mux.Router {
 	// Create a new router
 	router := mux.NewRouter()
 
 	// ------------------------------------
-	// Large configuration management
+	// General configuration management
 	// ------------------------------------
 
 	// Define the retrieval endpoints for Plunder Server configuration
@@ -43,6 +48,9 @@ func setAPIEndpoints() *mux.Router {
 
 	// Define the retrieval endpoints for Plunder Deployment configuration
 	router.HandleFunc(fmt.Sprintf("%s", DeploymentsAPIPath()), postDeployments).Methods("POST")
+
+	// Define the retrieval endpoints for Plunder Server configuration
+	router.HandleFunc(fmt.Sprintf("%s/{id}", DHCPAPIPath()), getDHCP).Methods("GET")
 
 	// ------------------------------------
 	// Specific configuration management

--- a/pkg/apiserver/handlerLease.go
+++ b/pkg/apiserver/handlerLease.go
@@ -1,0 +1,47 @@
+package apiserver
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/plunder-app/plunder/pkg/services"
+)
+
+// This package provides the capability to retrieve information about mac addresses (from DHCP) that plunder has seen or allocated
+
+// Retrieve the plunder server dhcp configuration
+func getDHCP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	var rsp Response
+
+	// Find the deployment ID
+	id := mux.Vars(r)["id"]
+
+	if id == "leases" {
+
+		jsonData, err := json.Marshal(services.Controller.GetLeases())
+		if err != nil {
+			w.Header().Set("Content-Type", "application/json")
+			rsp.FriendlyError = "Error retrieving allocated leases"
+			rsp.Error = err.Error()
+		} else {
+			rsp.Payload = jsonData
+		}
+	}
+	// Are we updating the deployment "global"
+	if id == "unleased" {
+
+		jsonData, err := json.Marshal(services.Controller.GetUnLeased())
+
+		if err != nil {
+			w.Header().Set("Content-Type", "application/json")
+			rsp.FriendlyError = "Error retrieving allocated leases"
+			rsp.Error = err.Error()
+		} else {
+			rsp.Payload = jsonData
+		}
+	}
+
+	json.NewEncoder(w).Encode(rsp)
+}

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -74,7 +74,8 @@ func (c *BootController) StartServices(deployment []byte) {
 
 		c.handler.LeaseDuration = 2 * time.Hour //TODO, make time modifiable
 		c.handler.LeaseRange = *c.DHCPConfig.DHCPLeasePool
-		c.handler.Leases = make(map[int]lease, *c.DHCPConfig.DHCPLeasePool)
+		// Initialise the two maps
+		c.handler.Leases = make(map[int]Lease, *c.DHCPConfig.DHCPLeasePool)
 
 		c.handler.Options = dhcp.Options{
 			dhcp.OptionSubnetMask:       []byte{255, 255, 255, 0},


### PR DESCRIPTION
A `/dhcp/ {leases/unleased}` endpoint allows exposure of unclaimed/claimed hardware.