### PR TITLE
This ensures that the logging isn't restarted

### DIFF
--- a/pkg/parlay/parser.go
+++ b/pkg/parlay/parser.go
@@ -29,9 +29,11 @@ func (m *TreasureMap) DeploySSH(logFile string, jsonLogging bool) error {
 		logger.InitLogFile(logFile)
 
 	}
+
 	if jsonLogging {
 		logger.InitJSON()
 	}
+
 	defer logger.SetLoggingState("", "Finished")
 
 	if len(ssh.Hosts) == 0 {

--- a/pkg/plunderlogging/logger.go
+++ b/pkg/plunderlogging/logger.go
@@ -17,11 +17,21 @@ func (l *Logger) EnableFileLogging(e bool) {
 }
 
 func (l *Logger) InitLogFile(path string) error {
-	return l.file.initFileLogger(path)
+	if l.file.enabled != true {
+		return l.file.initFileLogger(path)
+	}
+	// Dont re-initialise the file
+	return nil
+
 }
 
 func (l *Logger) InitJSON() {
-	l.json.initJSONLogger()
+	// Dont re-initialise the json
+
+	if l.json.enabled != true {
+		l.json.initJSONLogger()
+	}
+
 }
 
 // target - the entity we're affecting


### PR DESCRIPTION
This won't re-init the logging when a new deployment is started.