### PR TITLE
Large re-organisation of code

### DIFF
--- a/cmd/configGenerator.go
+++ b/cmd/configGenerator.go
@@ -11,8 +11,7 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/plunder-app/plunder/pkg/apiserver"
 	"github.com/plunder-app/plunder/pkg/certs"
-	"github.com/plunder-app/plunder/pkg/parlay"
-	"github.com/plunder-app/plunder/pkg/parlay/types"
+	"github.com/plunder-app/plunder/pkg/parlay/parlaytypes"
 	"github.com/plunder-app/plunder/pkg/services"
 	"github.com/plunder-app/plunder/pkg/utils"
 
@@ -143,7 +142,7 @@ var PlunderParlayConfig = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		log.SetLevel(log.Level(logLevel))
 
-		parlayActionPackage := types.Action{
+		parlayActionPackage := parlaytypes.Action{
 			Name:         "Add package",
 			ActionType:   "pkg",
 			PkgManager:   "apt",
@@ -151,34 +150,34 @@ var PlunderParlayConfig = &cobra.Command{
 			Packages:     "mysql",
 		}
 
-		parlayActionCommand := types.Action{
+		parlayActionCommand := parlaytypes.Action{
 			Name:             "Run Command",
 			ActionType:       "command",
 			Command:          "which uptime",
 			CommandSudo:      "root",
 			CommandSaveAsKey: "cmdKey",
 		}
-		parlayActionUpload := types.Action{
+		parlayActionUpload := parlaytypes.Action{
 			Name:        "Upload File",
 			ActionType:  "upload",
 			Source:      "./my_file",
 			Destination: "/tmp/file",
 		}
 
-		parlayActionDownload := types.Action{
+		parlayActionDownload := parlaytypes.Action{
 			Name:        "Download File",
 			ActionType:  "download",
 			Destination: "./my_file",
 			Source:      "/tmp/file",
 		}
 
-		parlayActionKey := types.Action{
+		parlayActionKey := parlaytypes.Action{
 			Name:       "Execute key",
 			ActionType: "command",
 			KeyName:    "cmdKey",
 		}
 
-		parlayDeployment := parlay.Deployment{
+		parlayDeployment := parlaytypes.Deployment{
 			Name:  "Install MySQL",
 			Hosts: []string{"192.168.0.1", "192.168.0.2"},
 		}
@@ -189,8 +188,8 @@ var PlunderParlayConfig = &cobra.Command{
 		parlayDeployment.Actions = append(parlayDeployment.Actions, parlayActionDownload)
 		parlayDeployment.Actions = append(parlayDeployment.Actions, parlayActionKey)
 
-		parlayConfig := &parlay.TreasureMap{}
-		parlayConfig.Deployments = []parlay.Deployment{}
+		parlayConfig := &parlaytypes.TreasureMap{}
+		parlayConfig.Deployments = []parlaytypes.Deployment{}
 		parlayConfig.Deployments = append(parlayConfig.Deployments, parlayDeployment)
 
 		// Render the output to screen

--- a/pkg/apiserver/handlersParlay.go
+++ b/pkg/apiserver/handlersParlay.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/plunder-app/plunder/pkg/parlay"
+	"github.com/plunder-app/plunder/pkg/parlay/parlaytypes"
 	"github.com/plunder-app/plunder/pkg/services"
 	"github.com/plunder-app/plunder/pkg/ssh"
 
@@ -21,8 +22,8 @@ func postParlay(w http.ResponseWriter, r *http.Request) {
 
 	if b, err := ioutil.ReadAll(r.Body); err == nil {
 		// Parse the treasure map in the POST data
-		var p parlay.TreasureMap
-		err := json.Unmarshal(b, &p)
+		var m parlaytypes.TreasureMap
+		err := json.Unmarshal(b, &m)
 		// Unable to parse the JSON payload
 		if err != nil {
 			rsp.FriendlyError = "Error parsing the parlay actions"
@@ -35,7 +36,7 @@ func postParlay(w http.ResponseWriter, r *http.Request) {
 				rsp.FriendlyError = "Error parsing the parlay actions"
 				rsp.Error = err.Error()
 			} else {
-				err = p.DeploySSH("", true, true)
+				err = parlay.DeploySSH(&m,"", true, true)
 				if err != nil {
 					rsp.FriendlyError = "Error parsing the parlay actions"
 					rsp.Error = err.Error()

--- a/pkg/parlay/parlay.go
+++ b/pkg/parlay/parlay.go
@@ -1,7 +1,5 @@
 package parlay
 
-import "github.com/plunder-app/plunder/pkg/parlay/types"
-
 type actionType string
 
 const (
@@ -11,28 +9,6 @@ const (
 	command  actionType = "command"
 	pkg      actionType = "package"
 )
-
-// TreasureMap - X Marks the spot
-// The treasure maps define the automation that will take place on the hosts defined
-type TreasureMap struct {
-	// An array/list of deployments that will take places as part of this "map"
-	Deployments []Deployment `json:"deployments"`
-}
-
-// Deployment defines the hosts and the action(s) that should be performed on them
-type Deployment struct {
-	// Name of the deployment that is taking place i.e. (Install MySQL)
-	Name string `json:"name"`
-	// An array/list of hosts that these actions should be performed upon
-	Hosts []string `json:"hosts"`
-
-	// Parallel allow multiple actions across multiple hosts in parallel
-	Parallel         bool `json:"parallel"`
-	ParallelSessions int  `json:"parallelSessions"`
-
-	// The actions that should be performed
-	Actions []types.Action `json:"actions"`
-}
 
 // KeyMap
 

--- a/pkg/parlay/parlay_ui.go
+++ b/pkg/parlay/parlay_ui.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/AlecAivazis/survey"
+	"github.com/plunder-app/plunder/pkg/parlay/parlaytypes"
 )
 
 func contains(v string, a []string) bool {
@@ -17,7 +18,7 @@ func contains(v string, a []string) bool {
 }
 
 // StartUI will enable parlay to provide an easier way of selecting which operations will be performed
-func (m *TreasureMap) StartUI() (*TreasureMap, error) {
+func StartUI(m *parlaytypes.TreasureMap) (*parlaytypes.TreasureMap, error) {
 
 	deployments := []string{}
 	for i := range m.Deployments {
@@ -46,7 +47,7 @@ func (m *TreasureMap) StartUI() (*TreasureMap, error) {
 	}
 
 	// Create a new TreasureMap from the answered questions
-	newMap, err := m.findDeployments(deploymentAnswers)
+	newMap, err := m.FindDeployments(deploymentAnswers)
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +87,7 @@ func (m *TreasureMap) StartUI() (*TreasureMap, error) {
 		}
 
 		newMap.Deployments[i].Hosts = hostAnswers
-		foundActions, err := newMap.Deployments[i].findActions(deploymentAnswers)
+		foundActions, err := newMap.Deployments[i].FindActions(deploymentAnswers)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/parlay/parlaytypes/finder.go
+++ b/pkg/parlay/parlaytypes/finder.go
@@ -1,14 +1,13 @@
-package parlay
+package parlaytypes
 
 import (
 	"fmt"
 
-	"github.com/plunder-app/plunder/pkg/parlay/types"
 	log "github.com/sirupsen/logrus"
 )
 
 // This will iterate through a deployment map and build a new deployment map from found deployments
-func (m *TreasureMap) findDeployments(deployment []string) (*TreasureMap, error) {
+func (m *TreasureMap) FindDeployments(deployment []string) (*TreasureMap, error) {
 
 	var newDeploymentList []Deployment
 
@@ -27,7 +26,7 @@ func (m *TreasureMap) findDeployments(deployment []string) (*TreasureMap, error)
 	return m, nil
 }
 
-func (d *Deployment) findHosts(hosts []string) (*Deployment, error) {
+func (d *Deployment) FindHosts(hosts []string) (*Deployment, error) {
 
 	var newHostList []string
 
@@ -46,8 +45,8 @@ func (d *Deployment) findHosts(hosts []string) (*Deployment, error) {
 	return d, nil
 }
 
-func (d *Deployment) findActions(actions []string) ([]types.Action, error) {
-	var newActionList []types.Action
+func (d *Deployment) FindActions(actions []string) ([]Action, error) {
+	var newActionList []Action
 
 	for x := range actions {
 		for y := range d.Actions {
@@ -64,7 +63,7 @@ func (d *Deployment) findActions(actions []string) ([]types.Action, error) {
 }
 
 //FindDeployment - takes a number of flags and builds a new map to be processed
-func (m *TreasureMap) FindDeployment(deployment, action, host, logFile string, resume bool) error {
+func (m *TreasureMap) FindDeployment(deployment, action, host, logFile string, resume bool) (*TreasureMap, error) {
 	var foundMap TreasureMap
 	if deployment != "" {
 		log.Debugf("Looking for deployment [%s]", deployment)
@@ -88,7 +87,7 @@ func (m *TreasureMap) FindDeployment(deployment, action, host, logFile string, r
 					}
 					// If this is zero it means that no actions have been found
 					if len(foundMap.Deployments[0].Actions) == 0 {
-						return fmt.Errorf("No actions have been found, looking for action [%s]", action)
+						return nil, fmt.Errorf("No actions have been found, looking for action [%s]", action)
 					}
 				}
 				// If a host is specified act soley on it
@@ -103,17 +102,18 @@ func (m *TreasureMap) FindDeployment(deployment, action, host, logFile string, r
 					}
 					// If this is zero it means that no hosts have been found
 					if len(foundMap.Deployments[0].Hosts) == 0 {
-						return fmt.Errorf("No host has been found, looking for host [%s]", host)
+						return nil, fmt.Errorf("No host has been found, looking for host [%s]", host)
 					}
 				}
 			}
 		}
 		// If this is zero it means that no actions have been found
 		if len(foundMap.Deployments) == 0 {
-			return fmt.Errorf("No deployment has been found, looking for deployment [%s]", deployment)
+			return nil, fmt.Errorf("No deployment has been found, looking for deployment [%s]", deployment)
 		}
 	} else {
-		return fmt.Errorf("No deployment was specified")
+		return nil, fmt.Errorf("No deployment was specified")
 	}
-	return foundMap.DeploySSH(logFile, false, false)
+	return &foundMap, nil
+	//return parlay.DeploySSH(foundMap, logFile, false, false)
 }

--- a/pkg/parlay/parlaytypes/parlaytypes.go
+++ b/pkg/parlay/parlaytypes/parlaytypes.go
@@ -1,6 +1,30 @@
-package types
+package parlaytypes
 
-import "encoding/json"
+import (
+	"encoding/json"
+)
+
+// TreasureMap - X Marks the spot
+// The treasure maps define the automation that will take place on the hosts defined
+type TreasureMap struct {
+	// An array/list of deployments that will take places as part of this "map"
+	Deployments []Deployment `json:"deployments"`
+}
+
+// Deployment defines the hosts and the action(s) that should be performed on them
+type Deployment struct {
+	// Name of the deployment that is taking place i.e. (Install MySQL)
+	Name string `json:"name"`
+	// An array/list of hosts that these actions should be performed upon
+	Hosts []string `json:"hosts"`
+
+	// Parallel allow multiple actions across multiple hosts in parallel
+	Parallel         bool `json:"parallel"`
+	ParallelSessions int  `json:"parallelSessions"`
+
+	// The actions that should be performed
+	Actions []Action `json:"actions"`
+}
 
 // Action defines what the instructions that will be executed
 type Action struct {

--- a/pkg/parlay/parser.go
+++ b/pkg/parlay/parser.go
@@ -7,8 +7,8 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	"github.com/plunder-app/plunder/pkg/parlay/parlaytypes"
 	parlayplugin "github.com/plunder-app/plunder/pkg/parlay/plugin"
-	"github.com/plunder-app/plunder/pkg/parlay/types"
 	"github.com/plunder-app/plunder/pkg/ssh"
 )
 
@@ -26,7 +26,7 @@ func DeleteTargetLogs(target string) error {
 }
 
 // DeploySSH - will iterate through a deployment and perform the relevant actions
-func (m *TreasureMap) DeploySSH(logFile string, jsonLogging, background bool) error {
+func DeploySSH(m *parlaytypes.TreasureMap, logFile string, jsonLogging, background bool) error {
 
 	// ERROR Checking
 	if len(ssh.Hosts) == 0 {
@@ -108,7 +108,7 @@ func (m *TreasureMap) DeploySSH(logFile string, jsonLogging, background bool) er
 	return nil
 }
 
-func startDeployments(d []Deployment) error {
+func startDeployments(d []parlaytypes.Deployment) error {
 	for x := range d {
 		// Build new hosts list from imported SSH servers and compare that we have required credentials
 		hosts, err := ssh.FindHosts(d[x].Hosts)
@@ -156,7 +156,7 @@ func startDeployments(d []Deployment) error {
 }
 
 // Begin host by host deployments as part of each deployment
-func sequentialDeployment(action []types.Action, hostConfig ssh.HostSSHConfig, logger *plunderlogging.Logger) error {
+func sequentialDeployment(action []parlaytypes.Action, hostConfig ssh.HostSSHConfig, logger *plunderlogging.Logger) error {
 	var err error
 
 	for y := range action {
@@ -246,7 +246,7 @@ func sequentialDeployment(action []types.Action, hostConfig ssh.HostSSHConfig, l
 
 // Peform all of the actions in parallel on all hosts in the host array
 // this function will make use of the parallel ssh calls
-func parallelDeployment(action []types.Action, hosts []ssh.HostSSHConfig, logger *plunderlogging.Logger) error {
+func parallelDeployment(action []parlaytypes.Action, hosts []ssh.HostSSHConfig, logger *plunderlogging.Logger) error {
 	for y := range action {
 		switch action[y].ActionType {
 		case "upload":

--- a/pkg/parlay/parser_builder.go
+++ b/pkg/parlay/parser_builder.go
@@ -6,12 +6,12 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/plunder-app/plunder/pkg/parlay/types"
+	"github.com/plunder-app/plunder/pkg/parlay/parlaytypes"
 	"github.com/plunder-app/plunder/pkg/ssh"
 	log "github.com/sirupsen/logrus"
 )
 
-func buildCommand(a types.Action) (string, error) {
+func buildCommand(a parlaytypes.Action) (string, error) {
 	var command string
 
 	// An executable Key takes presedence
@@ -40,7 +40,7 @@ func buildCommand(a types.Action) (string, error) {
 	return command, nil
 }
 
-func parseAndExecute(a types.Action, h *ssh.HostSSHConfig) ssh.CommandResult {
+func parseAndExecute(a parlaytypes.Action, h *ssh.HostSSHConfig) ssh.CommandResult {
 	// This will parse the options passed in the action and execute the required string
 	var cr ssh.CommandResult
 	var b []byte

--- a/pkg/parlay/plugin/plugin.go
+++ b/pkg/parlay/plugin/plugin.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"plugin"
 
-	"github.com/plunder-app/plunder/pkg/parlay/types"
+	"github.com/plunder-app/plunder/pkg/parlay/parlaytypes"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -174,7 +174,7 @@ func UsagePlugin(pluginPath, action string) {
 		return
 	}
 
-	a := types.Action{
+	a := parlaytypes.Action{
 		Name:       fmt.Sprintf("Example name for action [%s]", action),
 		ActionType: action,
 		Plugin:     result,
@@ -184,7 +184,7 @@ func UsagePlugin(pluginPath, action string) {
 }
 
 // ExecuteAction uses the cache to find an action/plugin mapping
-func ExecuteAction(action, host string, raw json.RawMessage) ([]types.Action, error) {
+func ExecuteAction(action, host string, raw json.RawMessage) ([]parlaytypes.Action, error) {
 	if pluginCache[action] == "" {
 		// No KeyMap meaning that the action doesn't map to a plugin
 		return nil, fmt.Errorf("Action [%s] does not exist or has no plugin associated with it", action)
@@ -193,7 +193,7 @@ func ExecuteAction(action, host string, raw json.RawMessage) ([]types.Action, er
 }
 
 // ExecuteActionInPlugin specifies the plugin and action directly
-func ExecuteActionInPlugin(pluginPath, action, host string, raw json.RawMessage) ([]types.Action, error) {
+func ExecuteActionInPlugin(pluginPath, action, host string, raw json.RawMessage) ([]parlaytypes.Action, error) {
 
 	// Check a function with the name ParlayExec exists
 	symbol, err := findFunctionInPlugin(pluginPath, "ParlayExec")
@@ -202,7 +202,7 @@ func ExecuteActionInPlugin(pluginPath, action, host string, raw json.RawMessage)
 	}
 	log.Debugf("Attempting plugin [%s]", action)
 	// Check the function has the correct parameters
-	pluginExec, ok := symbol.(func(string, string, json.RawMessage) ([]types.Action, error))
+	pluginExec, ok := symbol.(func(string, string, json.RawMessage) ([]parlaytypes.Action, error))
 	if !ok {
 		return nil, fmt.Errorf("Unable to read functions from Plugin [%s]", pluginPath)
 	}

--- a/pkg/parlay/validate.go
+++ b/pkg/parlay/validate.go
@@ -3,11 +3,11 @@ package parlay
 import (
 	"fmt"
 
-	"github.com/plunder-app/plunder/pkg/parlay/types"
+	"github.com/plunder-app/plunder/pkg/parlay/parlaytypes"
 )
 
 // ValidateAction will parse an action to ensure it is valid
-func ValidateAction(action *types.Action) error {
+func ValidateAction(action *parlaytypes.Action) error {
 	switch action.ActionType {
 	case "upload":
 		// Validate the upload action


### PR DESCRIPTION
This moves the remaining parlay types into a seperate package, this creates a clear seperation of data and function. This also reduces the footprint for clients that just need to build a parlay map and pass to the API server.