### PR TITLE
Can now read and expose the contents of an ISO

### DIFF
--- a/pkg/apiserver/endpoints.go
+++ b/pkg/apiserver/endpoints.go
@@ -66,6 +66,7 @@ func setAPIEndpoints() *mux.Router {
 
 	// Define the creation endpoints for Plunder Server Boot Configuration
 	router.HandleFunc(fmt.Sprintf("%s/{id}", ConfigAPIPath()), postBootConfig).Methods("POST")
+	router.HandleFunc(fmt.Sprintf("%s/{id}", ConfigAPIPath()), deleteBootConfig).Methods("DELETE")
 
 	// Define the creation and modification endpoints for Plunder Deployment configuration
 	router.HandleFunc(fmt.Sprintf("%s", DeploymentAPIPath()), postDeployment).Methods("POST")

--- a/pkg/services/server.go
+++ b/pkg/services/server.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/ghodss/yaml"
+	log "github.com/sirupsen/logrus"
 )
 
 // This is needed by other functions to build strings
@@ -36,6 +37,55 @@ func ParseControllerData(b []byte) error {
 		}
 	}
 	return nil
+}
+
+// ParseBootController - will iterate through the boot controller and see if any changes need applying
+// this is mainly for the dynamic loading of ISOs
+func (c *BootController) ParseBootController() error {
+
+	for i := range c.BootConfigs {
+		// If either the prefix or path are blank then iterate over, both need to be set in order to load the ISO
+		if c.BootConfigs[i].ISOPrefix == "" || c.BootConfigs[i].ISOPath == "" {
+			log.Debugf("No ISO is being parsed for configuration %s", c.BootConfigs[i].ConfigName)
+		} else {
+
+			// Create the prefix
+			urlPrefix := fmt.Sprintf("/%s/", c.BootConfigs[i].ISOPrefix)
+
+			// Only create the handler if one doesn't exist
+			if _, ok := isoMapper[c.BootConfigs[i].ISOPrefix]; !ok {
+				log.Debugf("Adding handler %s", urlPrefix)
+
+				mux.HandleFunc(urlPrefix, isoReader)
+			}
+
+			// Atempt to open the ISO and add it to the map for usage later
+			err := OpenISO(c.BootConfigs[i].ISOPath, c.BootConfigs[i].ISOPrefix)
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf("%v", isoMapper)
+			log.Debugf("Updating handler %s for config %s", urlPrefix, c.BootConfigs[i].ConfigName)
+
+		}
+	}
+	return nil
+}
+
+// DeleteBootControllerConfig - will iterate through the boot controller and see if any changes need applying
+// this is mainly for the dynamic loading of ISOs
+func (c *BootController) DeleteBootControllerConfig(configName string) error {
+
+	for i := range c.BootConfigs {
+		if c.BootConfigs[i].ConfigName == configName {
+			// Remove the mapping to an ISO path
+			isoMapper[c.BootConfigs[i].ISOPrefix] = ""
+			c.BootConfigs = append(c.BootConfigs[:i], c.BootConfigs[i+1:]...)
+			return nil
+		}
+	}
+	return fmt.Errorf("Unable to find boot configuration %s", configName)
 }
 
 // ParseDeployment will read in a byte array and attempt to parse it as yaml or json

--- a/pkg/services/server.go
+++ b/pkg/services/server.go
@@ -70,6 +70,8 @@ func (c *BootController) ParseBootController() error {
 
 		}
 	}
+	// Parse the boot controllers for new configuration changes
+	c.generateBootTypeHanders()
 	return nil
 }
 

--- a/pkg/services/serverHTTP.go
+++ b/pkg/services/serverHTTP.go
@@ -17,7 +17,7 @@ var controller *BootController
 
 var mux *http.ServeMux
 
-func (c BootController) generateBootTypeHanders(mux *http.ServeMux) {
+func (c *BootController) generateBootTypeHanders(mux *http.ServeMux) {
 
 	// Find the default configuration
 	defaultConfig := findBootConfigForName("default")

--- a/pkg/services/serverHTTP.go
+++ b/pkg/services/serverHTTP.go
@@ -17,13 +17,12 @@ var controller *BootController
 
 var mux *http.ServeMux
 
-func (c *BootController) generateBootTypeHanders(mux *http.ServeMux) {
+func (c *BootController) generateBootTypeHanders() {
 
 	// Find the default configuration
 	defaultConfig := findBootConfigForName("default")
 	if defaultConfig != nil {
 		defaultBoot = utils.IPXEPreeseed(*c.HTTPAddress, defaultConfig.Kernel, defaultConfig.Initrd, defaultConfig.Cmdline)
-		mux.HandleFunc("/default.ipxe", rootHandler)
 	} else {
 		log.Warnf("Found [%d] configurations and no \"default\" configuration", len(c.BootConfigs))
 	}
@@ -33,28 +32,25 @@ func (c *BootController) generateBootTypeHanders(mux *http.ServeMux) {
 	if preeseedConfig != nil {
 		preseed = utils.IPXEPreeseed(*c.HTTPAddress, preeseedConfig.Kernel, preeseedConfig.Initrd, preeseedConfig.Cmdline)
 
-		mux.HandleFunc("/preseed.ipxe", preseedHandler)
 	}
 
 	// If a kickstart configuration has been configured then add it, and create a HTTP endpoint
 	kickstartConfig := findBootConfigForName("kickstart")
 	if kickstartConfig != nil {
 		kickstart = utils.IPXEPreeseed(*c.HTTPAddress, kickstartConfig.Kernel, kickstartConfig.Initrd, kickstartConfig.Cmdline)
-		mux.HandleFunc("/kickstart.ipxe", kickstartHandler)
 	}
 
 	// If a vsphereConfig configuration has been configured then add it, and create a HTTP endpoint
 	vsphereConfig := findBootConfigForName("vsphere")
 	if vsphereConfig != nil {
 		vsphere = utils.IPXEVSphere(*c.HTTPAddress, vsphereConfig.Kernel, vsphereConfig.Cmdline)
-		mux.HandleFunc("/vsphere.ipxe", vsphereHandler)
 	}
 }
 
 func (c *BootController) serveHTTP() error {
 
 	// This function will pre-generate the boot handlers for the various boot types
-	c.generateBootTypeHanders(mux)
+	c.generateBootTypeHanders()
 
 	autoBoot = utils.IPXEAutoBoot()
 	reboot = utils.IPXEReboot()
@@ -64,10 +60,19 @@ func (c *BootController) serveHTTP() error {
 		return err
 	}
 
+	// Created only once
+
+	// TOTO - alloew this to be customisable
 	mux.Handle("/", http.FileServer(http.Dir(docroot)))
+
+	// Boot handlers
 	mux.HandleFunc("/health", HealthCheckHandler)
 	mux.HandleFunc("/reboot.ipxe", rebootHandler)
 	mux.HandleFunc("/autoBoot.ipxe", autoBootHandler)
+	mux.HandleFunc("/default.ipxe", rootHandler)
+	mux.HandleFunc("/kickstart.ipxe", kickstartHandler)
+	mux.HandleFunc("/preseed.ipxe", preseedHandler)
+	mux.HandleFunc("/vsphere.ipxe", vsphereHandler)
 
 	// Set the pointer to the boot config
 	controller = c

--- a/pkg/services/serverHTTPISO.go
+++ b/pkg/services/serverHTTPISO.go
@@ -1,0 +1,193 @@
+package services
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/hooklift/iso9660"
+	log "github.com/sirupsen/logrus"
+)
+
+// TODO - This currently is inefficient and results in an open/parse of an iso for every file operation.
+// github.com/qeedquan/iso9660 may need looking at later on. ( thebsdbox / [1/9/19] )
+// Comments are left incase we/I revert
+
+// isoMapper at this point just maps the prefix to the path this may change
+var isoMapper map[string]string
+
+// iso9660PathSanitiser will take a "standar" file path and convert it into something that make sense within iso9660 TOC
+// The iso9660 constraints:
+// - A-Z (uppercase)
+// - '_' is the only other character
+// - Filename can only be 32 characters (inclucing the terminating semicolon ';')
+
+func iso9660PathSanitiser(unsanitisedPath string) string {
+	// Get the filename from the string
+	fullFilename := filepath.Base(unsanitisedPath)
+	// Get the extension
+	extension := filepath.Ext(fullFilename)
+
+	// Remove the extension and leave just the filename
+	filename := strings.TrimSuffix(fullFilename, extension)
+	// Store the filename and shorten if over 31 characters
+
+	trimmedFilename := filename
+	pathLength := len(filename) + len(extension)
+	if pathLength > 31 {
+		// If the path is too long then we shrink the extension to a seperator and three characters
+		if len(extension) > 3 {
+			extension = extension[0:4]
+		}
+		// work out how much of the remaining filename can survive
+		trimCount := 31 - len(extension)
+		trimmedFilename = filename[0:trimCount]
+	}
+
+	rebuiltFileName := strings.ToUpper(fmt.Sprintf("%s%s", trimmedFilename, extension))
+	// Find if there is a full stop in the file name
+	stopCount := strings.Count(rebuiltFileName, ".")
+	var isoFilename string
+
+	switch stopCount {
+	case 0:
+		// Append one as there is no filepat
+		isoFilename = fmt.Sprintf("%s.;1", rebuiltFileName)
+	case 1:
+		// Not needed, just the semicolon
+		isoFilename = fmt.Sprintf("%s;1", rebuiltFileName)
+	default:
+		// Ensure all other stops are changed to underscores
+		isoFilename = fmt.Sprintf("%s;1", strings.Replace(rebuiltFileName, ".", "_", stopCount-1))
+	}
+
+	//rebuild the path uppercase
+	rebuildPath := strings.ToUpper(fmt.Sprintf("%s/%s", filepath.Dir(unsanitisedPath), isoFilename))
+
+	// strD replacer
+	replacer := strings.NewReplacer("+", "_", "-", "_", " ", "_", "~", "_")
+	// Format the final output
+	isoFormatted := replacer.Replace(rebuildPath)
+
+	return isoFormatted
+}
+
+// This takes care of parsing a URL to identify if it should map to an ISO hosted file.
+
+// ISOReader -
+func isoReader(w http.ResponseWriter, r *http.Request) {
+
+	// Sanitise the URL, there are a number of steps involved with turning the url into something we can use
+	// Remove the beginning slash
+	rawURL := strings.TrimLeft(r.URL.String(), "/")
+
+	// Unescape the Http query
+	isoURL, err := url.QueryUnescape(rawURL)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		io.WriteString(w, fmt.Sprintf("%s", err.Error()))
+
+		return
+	}
+
+	// Split the URL to find the prefix (first part of the URL)
+	urlElements := strings.Split(isoURL, "/")
+	// Ensure the URL can be parsed
+	if len(urlElements) > 1 {
+		isoPrefix := urlElements[0]
+
+		isoPath := iso9660PathSanitiser(strings.Replace(isoURL, isoPrefix, "", 1))
+
+		// We now have the ISO prefix to look up files, and the path to look up in the ISO
+		//Check for ISO
+		log.Debugf("Original URL: %s ISO Path: %s", isoURL, isoPath)
+		if _, ok := isoMapper[isoPrefix]; ok {
+			file, err := os.Open(isoMapper[isoPrefix])
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				io.WriteString(w, fmt.Sprintf("%s", err.Error()))
+
+				return
+			}
+			defer file.Close()
+			r, err := iso9660.NewReader(file)
+			if err != nil {
+				fmt.Printf("%v", err)
+				return
+			}
+			for {
+
+				f, err := r.Next()
+				if err == io.EOF {
+					w.WriteHeader(http.StatusNotFound)
+					io.WriteString(w, fmt.Sprintf("Unable to read/find file %s", isoPath))
+					return
+				}
+				if f.Name() == isoPath {
+					freader := f.Sys().(io.Reader)
+					buf := new(bytes.Buffer)
+					buf.ReadFrom(freader)
+					w.WriteHeader(http.StatusOK)
+					w.Header().Set("Content-Type", "application/x-binary")
+					io.WriteString(w, buf.String())
+					return
+				}
+			}
+			// isoFile, err := isoMapper[isoPrefix].Open(isoPath)
+			// if err != nil {
+			// 	w.WriteHeader(http.StatusNotFound)
+			// 	io.WriteString(w, fmt.Sprintf("%s", err.Error()))
+			// 	return
+			// }
+
+			// fileStat, err := isoFile.Stat()
+			// if err != nil {
+			// 	w.WriteHeader(http.StatusNotFound)
+			// 	io.WriteString(w, fmt.Sprintf("Unable to stat file on ISO %s", isoPath))
+			// 	return
+			// }
+			// fileBytes = make([]byte, fileStat.Size())
+			// _, err = isoFile.Read(fileBytes)
+			// if err != nil {
+			// 	w.WriteHeader(http.StatusNotFound)
+			// 	io.WriteString(w, fmt.Sprintf("Unable to read file on ISO %s", isoPath))
+			// 	return
+			// }
+		}
+
+	} else {
+		w.WriteHeader(http.StatusNotFound)
+		io.WriteString(w, fmt.Sprintf("Unable to find content ISO Prefix %s", isoURL))
+		return
+	}
+	w.WriteHeader(http.StatusNotFound)
+	io.WriteString(w, fmt.Sprintf("Unable to find content ISO Prefix %s", isoURL))
+	return
+}
+
+// OpenISO will open an iso and add it to out ISO Map for reading at a later point
+func OpenISO(isoPath, isoPrefix string) error {
+	// file, err := os.Open(isoPath)
+	// if err != nil {
+	// 	return err
+	// }
+
+	// f, err := iso9660(isoPath)
+	// if err != nil {
+	// 	return err
+	// }
+
+	if isoMapper == nil {
+		// Ensure it is initialised before trying to use it
+		isoMapper = make(map[string]string)
+	}
+	// Add the reader
+	isoMapper[isoPrefix] = isoPath
+
+	return nil
+}

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -149,6 +149,14 @@ func (c *BootController) StartServices(deployment []byte) {
 		// Use of a Mux allows the redefinition of http paths
 		mux = http.NewServeMux()
 
+		// Parse the boot controller configuration
+		err := c.ParseBootController()
+
+		if err != nil {
+			// Don't quit on error as updated configuration can be uploaded through the API
+			log.Errorf("%v", err)
+		}
+
 		// If a Deployment file is set then update the configuration
 		if len(deployment) != 0 {
 			err := UpdateDeploymentConfig(deployment)

--- a/pkg/services/templatePreseed.go
+++ b/pkg/services/templatePreseed.go
@@ -136,7 +136,9 @@ d-i user-setup/encrypt-home boolean false
 const preseedPkg = `
 ### Apt setup
 d-i apt-setup/restricted boolean true
-d-i apt-setup/universe boolean true
+d-i apt-setup/universe boolean false
+di- apt-setup/security_host %s
+d-i apt-setup/security_path string %s
 d-i mirror/http/hostname string %s
 d-i mirror/http/directory string %s
 d-i mirror/country string manual
@@ -161,6 +163,7 @@ d-i pkgsel/language-pack-patterns string
 d-i pkgsel/language-packs multiselect
 # or ...
 #d-i pkgsel/language-packs multiselect en, pl
+#d-i debian-installer/allow_unauthenticated boolean true
 
 # Policy for applying updates. May be "none" (no automatic updates),
 # "unattended-upgrades" (install security updates automatically), or
@@ -201,7 +204,7 @@ func (config *HostConfig) BuildPreeSeedConfig() string {
 		parsedDisk = preseedDisk + noswap
 	}
 	parsedNet := fmt.Sprintf(preseedNet, config.Adapter, config.Gateway, config.IPAddress, config.NameServer, config.Subnet, config.ServerName)
-	parsedPkg := fmt.Sprintf(preseedPkg, config.RepositoryAddress, config.MirrorDirectory, config.Packages)
+	parsedPkg := fmt.Sprintf(preseedPkg, config.RepositoryAddress, config.MirrorDirectory, config.RepositoryAddress, config.MirrorDirectory, config.Packages)
 	parsedCmd := fmt.Sprintf(preseedCmd, key)
 	parsedUsr := fmt.Sprintf(preseedUsers, config.Username, config.Username, config.Password, config.Password)
 	return fmt.Sprintf("%s%s%s%s%s%s", preseedHead, parsedDisk, parsedNet, parsedPkg, parsedUsr, parsedCmd)

--- a/pkg/services/types.go
+++ b/pkg/services/types.go
@@ -37,10 +37,15 @@ type dhcpConfig struct {
 // BootConfig defines a named configuration for booting
 type BootConfig struct {
 	ConfigName string `json:"configName"`
+
 	// iPXE file settings - exported
 	Kernel  string `json:"kernelPath"`
 	Initrd  string `json:"initrdPath"`
 	Cmdline string `json:"cmdline"`
+
+	// ISO Reader settings
+	ISOPath   string `json:"isoPath,omitempty"`
+	ISOPrefix string `json:"isoPrefix,omitempty"`
 }
 
 // DeploymentConfigurationFile - The bootstraps.Configs is used by other packages to manage use case for Mac addresses


### PR DESCRIPTION
This PR enables `plunder` to use the content of an ISO without mounting it, removing the need for any elevated permissions. Prior to this a user would need to loopback mount an ISO and use that path as a boot mirror for the installation, with this in place we use a `isoPrefix` identifier and a path to expose the ISO as a content store to Plunder.


Usage is shown below:
```
# Delete the previous configuration for the preseed boot
pldrctl delete boot preseed; 

# Create a new boot with the use of an isoPath
pldrctl create boot -i ubuntu/install/netboot/ubuntu-installer/amd64/initrd.gz \
                                -k ubuntu/install/netboot/ubuntu-installer/amd64/linux \
                                -n preseed  \
    --isoPath "/mnt/Products/Operating Systems/Ubuntu/ubuntu-16.04.5-server-amd64.iso" \
    --isoPrefix ubuntu
```