### PR TITLE
The SSH Key is part of the hostConfig as base64

### DIFF
--- a/cmd/configGenerator.go
+++ b/cmd/configGenerator.go
@@ -104,7 +104,7 @@ var plunderDeploymentConfig = &cobra.Command{
 			Subnet:            "255.255.255.0",
 			Username:          "user",
 			Password:          "pass",
-			Packages:          "nginx openssh-server",
+			Packages:          "openssh-server",
 			RepositoryAddress: "192.168.0.1",
 			MirrorDirectory:   "/ubuntu",
 			SSHKeyPath:        "/home/deploy/.ssh/id_pub.rsa",

--- a/cmd/configGenerator.go
+++ b/cmd/configGenerator.go
@@ -29,6 +29,7 @@ func init() {
 	plunderCmd.AddCommand(plunderConfig)
 	plunderConfig.PersistentFlags().StringVarP(&output, "output", "o", "json", "Ouput type, should be either JSON or YAML")
 	plunderConfig.PersistentFlags().BoolVarP(&pretty, "pretty", "p", false, "Ouput JSON in a pretty/Human readable format")
+	plunderServerConfig.PersistentFlags().StringVarP(&detectNic, "nic", "n", "", "Build configuration for a particular network interface")
 
 	// Persistent above both client functions
 	plunderAPIConfig.PersistentFlags().IntVar(&configAPIServerPort, "port", 60443, "Port that the plunder API server should use")

--- a/pkg/parlay/handler.go
+++ b/pkg/parlay/handler.go
@@ -68,12 +68,12 @@ func postParlay(w http.ResponseWriter, r *http.Request) {
 			//
 			err = ssh.ImportHostsFromDeployment(services.Deployments)
 			if err != nil {
-				rsp.FriendlyError = "Error parsing the parlay actions"
+				rsp.FriendlyError = "Error importing the hosts from deployment"
 				rsp.Error = err.Error()
 			} else {
 				err = DeploySSH(&m, "", true, true)
 				if err != nil {
-					rsp.FriendlyError = "Error parsing the parlay actions"
+					rsp.FriendlyError = "Error performing the parlay actions"
 					rsp.Error = err.Error()
 					log.Errorf("%s", err.Error())
 				}

--- a/pkg/services/deployments.go
+++ b/pkg/services/deployments.go
@@ -20,11 +20,17 @@ func init() {
 	httpPaths = make(map[string]string)
 }
 
+// rebuildConfiguration - will parse the entire deployment configuration and update anything that is missing
 func rebuildConfiguration(updateConfig *DeploymentConfigurationFile) error {
 
 	// If HTTP isn't enabled we can't build the multiplexer for URLs
 	if serveMux == nil {
 		return fmt.Errorf("Deployment HTTP Server isn't enabled, so parsing deployments isn't possible")
+	}
+
+	// If a key is specified then we read it and base64 the file into the SSHKEY string
+	if updateConfig.GlobalServerConfig.SSHKeyPath != "" {
+
 	}
 
 	log.Debugf("Parsing [%d] Configurations", len(updateConfig.Configs))
@@ -126,10 +132,9 @@ func rebuildConfiguration(updateConfig *DeploymentConfigurationFile) error {
 
 // UpdateDeploymentConfig will read a configuration string and build the iPXE files needed
 func UpdateDeploymentConfig(rawDeploymentConfig []byte) error {
-
-	// Separate configuration until everything is processes correctly
-
+	// Read through the deployment configuration
 	log.Infoln("Updating the Deployment Configuration")
+	// Work out if it is a YAML/JSON or unknown
 	updateConfig, err := ParseDeployment(rawDeploymentConfig)
 	if err != nil {
 		return err

--- a/pkg/services/deployments.go
+++ b/pkg/services/deployments.go
@@ -30,11 +30,15 @@ func rebuildConfiguration(updateConfig *DeploymentConfigurationFile) error {
 
 	// If a key is specified then we read it and base64 the file into the SSHKEY string
 	if updateConfig.GlobalServerConfig.SSHKeyPath != "" {
-
+		err := updateConfig.GlobalServerConfig.parseSSH()
+		if err != nil {
+			log.Errorf(err.Error())
+		}
 	}
 
 	log.Debugf("Parsing [%d] Configurations", len(updateConfig.Configs))
 	for i := range updateConfig.Configs {
+
 		// inMemipxeConfig is a custom configuration that matches kernel/initrd & cmdline and is 00:11:22:33:44:55.ipxe
 		var inMemipxeConfig string
 
@@ -62,6 +66,16 @@ func rebuildConfiguration(updateConfig *DeploymentConfigurationFile) error {
 
 		// This will populate anything missing from the global configuration
 		updateConfig.Configs[i].ConfigHost.PopulateConfiguration(updateConfig.GlobalServerConfig)
+
+		// If a key is specified then we read it and base64 the file into the SSHKEY string
+		if updateConfig.Configs[i].ConfigHost.SSHKeyPath != "" {
+			err := updateConfig.Configs[i].ConfigHost.parseSSH()
+			if err != nil {
+				log.Errorf(err.Error())
+			}
+		} else {
+			log.Errorf("This server [%s] will be deployed with no SSH Key", updateConfig.Configs[i].ConfigHost.ServerName)
+		}
 
 		// Look for understood config types
 		switch updateConfig.Configs[i].ConfigName {

--- a/pkg/services/server.go
+++ b/pkg/services/server.go
@@ -65,7 +65,6 @@ func (c *BootController) ParseBootController() error {
 				return err
 			}
 
-			fmt.Printf("%v", isoMapper)
 			log.Debugf("Updating handler %s for config %s", urlPrefix, c.BootConfigs[i].ConfigName)
 
 		}

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -64,7 +64,7 @@ func (c *BootController) setBootConfig(configName, kernel, initrd, cmdline strin
 }
 
 // StartServices - This will start all of the enabled services
-func (c *BootController) StartServices(deployment []byte) {
+func (c *BootController) StartServices(deployment []byte) error {
 	log.Infof("Starting Remote Boot Services, press CTRL + c to stop")
 
 	if *c.EnableDHCP == true {
@@ -166,5 +166,6 @@ func (c *BootController) StartServices(deployment []byte) {
 			}
 		}
 	}
-
+	// everything has been started correctly
+	return nil
 }

--- a/pkg/services/templatePreseed.go
+++ b/pkg/services/templatePreseed.go
@@ -192,7 +192,9 @@ func (config *HostConfig) BuildPreeSeedConfig() string {
 	if config.SSHKeyPath != "" {
 		key, err = config.ReadKeyFromFile(config.SSHKeyPath)
 		if err != nil {
-			log.Fatalf("%v", err)
+			// At this point we could build a server with bad config
+			// TODO - :-/
+			log.Errorf("SSH Key: %v", err)
 		}
 	}
 

--- a/pkg/services/templateUtils.go
+++ b/pkg/services/templateUtils.go
@@ -1,16 +1,17 @@
 package services
 
 import (
+	"encoding/base64"
 	"io/ioutil"
 	"os"
 	"strings"
 )
 
 // ReadKeyFromFile - will attempt to read an sshkey from a file and populate the struct
-func (config *HostConfig) ReadKeyFromFile(sshKeyPath string) (string, error) {
+func (c *HostConfig) ReadKeyFromFile() (string, error) {
 	var buffer []byte
-	if _, err := os.Stat(sshKeyPath); !os.IsNotExist(err) {
-		buffer, err = ioutil.ReadFile(sshKeyPath)
+	if _, err := os.Stat(c.SSHKeyPath); !os.IsNotExist(err) {
+		buffer, err = ioutil.ReadFile(c.SSHKeyPath)
 		if err != nil {
 			// Unable to read the file
 			return "", err
@@ -25,62 +26,75 @@ func (config *HostConfig) ReadKeyFromFile(sshKeyPath string) (string, error) {
 	return singleLine, nil
 }
 
+// This will attempt to parse an SSH file in the host config and load it as a base64 encoded KEY
+func (c *HostConfig) parseSSH() error {
+	// If a file is specified then lets read it and base64 the results (as long as a key doesn't already exist)
+	if c.SSHKeyPath != "" && c.SSHKey == "" {
+		data, err := c.ReadKeyFromFile()
+		if err != nil {
+			return err
+		}
+		c.SSHKey = base64.StdEncoding.EncodeToString([]byte(data))
+	}
+	return nil
+}
+
 // PopulateConfiguration - This will read a deployment configuration and attempt to fill any missing fields from the global config
-func (config *HostConfig) PopulateConfiguration(globalConfig HostConfig) {
+func (c *HostConfig) PopulateConfiguration(globalConfig HostConfig) {
 	// NETWORK CONFIGURATION
 
 	// Inherit the global Gateway
-	if config.Gateway == "" {
-		config.Gateway = globalConfig.Gateway
+	if c.Gateway == "" {
+		c.Gateway = globalConfig.Gateway
 	}
 
 	// Inherit the global Subnet
-	if config.Subnet == "" {
-		config.Subnet = globalConfig.Subnet
+	if c.Subnet == "" {
+		c.Subnet = globalConfig.Subnet
 	}
 
 	// Inherit the global Name Server (DNS)
-	if config.NameServer == "" {
-		config.NameServer = globalConfig.NameServer
+	if c.NameServer == "" {
+		c.NameServer = globalConfig.NameServer
 	}
 
-	if config.Adapter == "" {
-		config.Adapter = globalConfig.Adapter
+	if c.Adapter == "" {
+		c.Adapter = globalConfig.Adapter
 	}
 
 	// REPOSITORY CONFIGURATION
 
 	// Inherit the global Repository address
-	if config.RepositoryAddress == "" {
-		config.RepositoryAddress = globalConfig.RepositoryAddress
+	if c.RepositoryAddress == "" {
+		c.RepositoryAddress = globalConfig.RepositoryAddress
 	}
 
 	// Inherit the global Repository Mirror directory (typically /ubuntu)
-	if config.MirrorDirectory == "" {
-		config.MirrorDirectory = globalConfig.MirrorDirectory
+	if c.MirrorDirectory == "" {
+		c.MirrorDirectory = globalConfig.MirrorDirectory
 	}
 
 	// USER CONFIGURATION
 
 	// Inherit the global Username
-	if config.Username == "" {
-		config.Username = globalConfig.Username
+	if c.Username == "" {
+		c.Username = globalConfig.Username
 	}
 
 	// Inherit the global Password
-	if config.Password == "" {
-		config.Password = globalConfig.Password
+	if c.Password == "" {
+		c.Password = globalConfig.Password
 	}
 
 	// Inherit the global SSH Key Path
-	if config.SSHKeyPath == "" {
-		config.SSHKeyPath = globalConfig.SSHKeyPath
+	if c.SSHKeyPath == "" {
+		c.SSHKeyPath = globalConfig.SSHKeyPath
 	}
 
 	// Package Configuration
 
 	// Inherit the global package selection
-	if config.Packages == "" {
-		config.Packages = globalConfig.Packages
+	if c.Packages == "" {
+		c.Packages = globalConfig.Packages
 	}
 }

--- a/pkg/services/types.go
+++ b/pkg/services/types.go
@@ -86,7 +86,7 @@ type HostConfig struct {
 
 	// SSHKeyPath will typically be referenced from a file ~/.ssh/id_rsa.pub
 	SSHKeyPath string `json:"sshkeypath,omitempty"`
-	// SSHKey is a full SSH Key
+	// SSHKey is a full SSH Key in base 64
 	SSHKey string `json:"sshkey,omitempty"`
 
 	// Packages to be installed


### PR DESCRIPTION
This will check if `hostConfig.SSHPath` is populated and attempt to read the key, if correct it will base64 the key into `hostConfig.SSHKey`. This is decrypted when building the pressed files, there is also a fix around `parlay` to make it attempt to use the default key first before attempting to "mangle" the existing public key into sometime useable. 