### PR TITLE
Added go.mo files

### DIFF
--- a/pkg/apiserver/go.mod
+++ b/pkg/apiserver/go.mod
@@ -1,0 +1,3 @@
+module github.com/plunder-app/plunder/pkg/apiserver
+
+go 1.12

--- a/pkg/parlay/go.mod
+++ b/pkg/parlay/go.mod
@@ -1,0 +1,3 @@
+module github.com/plunder-app/plunder/pkg/parlay
+
+go 1.12

--- a/pkg/parlay/parlaytypes/go.mod
+++ b/pkg/parlay/parlaytypes/go.mod
@@ -1,0 +1,3 @@
+module github.com/plunder-app/plunder/pkg/parlay/parlaytypes
+
+go 1.12

--- a/pkg/plunderlogging/go.mod
+++ b/pkg/plunderlogging/go.mod
@@ -1,0 +1,3 @@
+module github.com/plunder-app/plunder/pkg/plunderlogging
+
+go 1.12

--- a/pkg/services/go.mod
+++ b/pkg/services/go.mod
@@ -1,0 +1,3 @@
+module github.com/plunder-app/plunder/pkg/services
+
+go 1.12

--- a/pkg/utils/go.mod
+++ b/pkg/utils/go.mod
@@ -1,0 +1,3 @@
+module github.com/plunder-app/plunder/pkg/utils
+
+go 1.12


### PR DESCRIPTION
These `go.mod` files are required when GO modules are enabled. `export GO111MODULE=on`