### PR TITLE
This ensures that internal packages are reference by go.mod

### DIFF
--- a/pkg/certs/go.mod
+++ b/pkg/certs/go.mod
@@ -1,0 +1,3 @@
+module github.com/plunder-app/plunder/pkg/certs
+
+go 1.12

--- a/pkg/services/serverHTTPISO.go
+++ b/pkg/services/serverHTTPISO.go
@@ -67,7 +67,7 @@ func iso9660PathSanitiser(unsanitisedPath string) string {
 	}
 
 	//rebuild the path uppercase
-	rebuildPath := strings.ToUpper(fmt.Sprintf("%s/%s", filepath.Dir(unsanitisedPath), isoFilename))
+	rebuildPath := strings.ToLower(fmt.Sprintf("%s/%s", filepath.Dir(unsanitisedPath), isoFilename))
 
 	// strD replacer
 	replacer := strings.NewReplacer("+", "_", "-", "_", " ", "_", "~", "_")
@@ -127,7 +127,7 @@ func isoReader(w http.ResponseWriter, r *http.Request) {
 				if err == io.EOF {
 					w.WriteHeader(http.StatusNotFound)
 					io.WriteString(w, fmt.Sprintf("Unable to read/find file %s", isoPath))
-
+					log.Error(fmt.Sprintf("Unable to read/find file %s", isoPath))
 					return
 				}
 				if err != nil {
@@ -135,7 +135,7 @@ func isoReader(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				if strings.ToUpper(f.Name()) == isoPath {
+				if f.Name() == isoPath {
 					freader := f.Sys().(io.Reader)
 					buf := new(bytes.Buffer)
 					buf.ReadFrom(freader)

--- a/pkg/ssh/go.mod
+++ b/pkg/ssh/go.mod
@@ -1,0 +1,3 @@
+module github.com/plunder-app/plunder/pkg/ssh
+
+go 1.12


### PR DESCRIPTION
This fixes references in `go.mod` so that the build will reference the internal packages ensuring development work behaves as expected prior. Also fixes some error reporting from DHCP and ISO Reader.