### PR TITLE
Linter fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+
+.plunderserver.yaml
+plunder
+plunderclient.yaml

--- a/pkg/parlay/parlaytypes/finder.go
+++ b/pkg/parlay/parlaytypes/finder.go
@@ -6,7 +6,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// This will iterate through a deployment map and build a new deployment map from found deployments
+// FindDeployments - This will iterate through a deployment map and build a new deployment map from found deployments
 func (m *TreasureMap) FindDeployments(deployment []string) (*TreasureMap, error) {
 
 	var newDeploymentList []Deployment
@@ -26,6 +26,7 @@ func (m *TreasureMap) FindDeployments(deployment []string) (*TreasureMap, error)
 	return m, nil
 }
 
+// FindHosts - will iterate through the deployment hosts and compare to the array of hosts to return
 func (d *Deployment) FindHosts(hosts []string) (*Deployment, error) {
 
 	var newHostList []string
@@ -45,6 +46,7 @@ func (d *Deployment) FindHosts(hosts []string) (*Deployment, error) {
 	return d, nil
 }
 
+// FindActions - will iterate through the deployment actions and compare to the array of actions to return
 func (d *Deployment) FindActions(actions []string) ([]Action, error) {
 	var newActionList []Action
 

--- a/pkg/plunderlogging/logger.go
+++ b/pkg/plunderlogging/logger.go
@@ -2,20 +2,24 @@ package plunderlogging
 
 import "fmt"
 
+// Logger - is a stuct that manages the verious types of logger available
 type Logger struct {
 	json JSONLogger
 	file FileLogger
 }
 
+// EnableJSONLogging - will enable logging through JSON
 func (l *Logger) EnableJSONLogging(e bool) {
 	l.json.enabled = e
 	l.json.initJSONLogger()
 }
 
+// EnableFileLogging - will enable logging to a file
 func (l *Logger) EnableFileLogging(e bool) {
 	l.file.enabled = e
 }
 
+// InitLogFile - will initialise file based logging
 func (l *Logger) InitLogFile(path string) error {
 	if l.file.enabled != true {
 		return l.file.initFileLogger(path)
@@ -25,6 +29,7 @@ func (l *Logger) InitLogFile(path string) error {
 
 }
 
+// InitJSON - will start/initialise the JSON logging functionality
 func (l *Logger) InitJSON() {
 	// Dont re-initialise the json
 
@@ -50,6 +55,7 @@ func (l *Logger) WriteLogEntry(target, task, entry, err string) {
 
 }
 
+// SetLoggingState - currently a NOOP (TODO)
 func (l *Logger) SetLoggingState(target, state string) {
 	if l.file.enabled {
 		l.file.setLoggingState(target, state)
@@ -62,6 +68,7 @@ func (l *Logger) SetLoggingState(target, state string) {
 
 }
 
+// GetJSONLogs - returns a pointer to the current JSON Logs
 func (l *Logger) GetJSONLogs(target string) (*JSONLog, error) {
 	if l.json.logger == nil {
 		return nil, fmt.Errorf("JSON Logging hasn't been enabled")
@@ -74,6 +81,7 @@ func (l *Logger) GetJSONLogs(target string) (*JSONLog, error) {
 	return nil, fmt.Errorf("No Logs for Target [%s] exist", target)
 }
 
+// DeleteLogs - will remove logs for a particular target
 func (l *Logger) DeleteLogs(target string) error {
 	if l.json.logger == nil {
 		return nil


### PR DESCRIPTION
Thanks to a fix with the Makefile correct linting is now performed with the `make` command.

This PR fixes all of the missing comment warnings from the make, it also includes a `.gitignore` for certificates or the plunder binary.

**FROM**
```
$ make
make lint
pkg/parlay/parlaytypes/finder.go:9:1: comment on exported method TreasureMap.FindDeployments should be of the form "FindDeployments ..."
pkg/parlay/parlaytypes/finder.go:29:1: exported method Deployment.FindHosts should have comment or be unexported
pkg/parlay/parlaytypes/finder.go:48:1: exported method Deployment.FindActions should have comment or be unexported
pkg/plunderlogging/logger.go:5:6: exported type Logger should have comment or be unexported
pkg/plunderlogging/logger.go:10:1: exported method Logger.EnableJSONLogging should have comment or be unexported
pkg/plunderlogging/logger.go:15:1: exported method Logger.EnableFileLogging should have comment or be unexported
pkg/plunderlogging/logger.go:19:1: exported method Logger.InitLogFile should have comment or be unexported
pkg/plunderlogging/logger.go:28:1: exported method Logger.InitJSON should have comment or be unexported
pkg/plunderlogging/logger.go:53:1: exported method Logger.SetLoggingState should have comment or be unexported
pkg/plunderlogging/logger.go:65:1: exported method Logger.GetJSONLogs should have comment or be unexported
pkg/plunderlogging/logger.go:77:1: exported method Logger.DeleteLogs should have comment or be unexported
make vet
Building and Installing project
```

TO: 
```
$ make
make lint
make vet
Building and Installing project
```