### PR TITLE
Update of Makefile for v0.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,11 @@ TARGET := plunder
 .DEFAULT_GOAL: $(TARGET)
 
 # These will be provided to the target
-VERSION := 0.4.5
+VERSION := 0.5.0
 BUILD := `git rev-parse HEAD`
+
+# Required for the move to go modules for >v0.5.0
+export GO111MODULE=on
 
 # Operating System Default (LINUX)
 TARGETOS=linux
@@ -15,7 +18,7 @@ TARGETOS=linux
 # Use linker flags to provide version/build settings to the target
 LDFLAGS=-ldflags "-X=main.Version=$(VERSION) -X=main.Build=$(BUILD) -s"
 
-SRC = "./..."
+#SRC = "."
 
 DOCKERTAG=latest
 
@@ -24,7 +27,7 @@ DOCKERTAG=latest
 all: check install
 
 $(TARGET): $(SRC)
-	@go build $(LDFLAGS) -o $(TARGET)
+	@go build $(LDFLAGS) -o $(TARGET) ./main.go
 
 build: $(TARGET)
 	@true

--- a/dockerfile/build/build.sh
+++ b/dockerfile/build/build.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+echo "Scooping up recent copy of code"
+
+tar -cf plunder.tar ../../cmd ../../pkg ../../main.go ../../Makefile ../../go.mod ../../go.sum
+
+docker build -t plunder:build .
+
+docker run -it --rm plunder:build /go/bin/plunder version
+
+echo ""
+echo "Remove the code copy rm plunder.tar"
+echo "Remove the local test docker container docker rmi plunder:build"

--- a/dockerfile/build/dockerfile
+++ b/dockerfile/build/dockerfile
@@ -1,0 +1,18 @@
+FROM golang:1.12.5
+
+# Install the linter
+RUN go get -u golang.org/x/lint/golint
+
+RUN mkdir -p /go/src/github.com/plunder-app/plunder/dockerfile/build
+
+WORKDIR /go/src/github.com/plunder-app/plunder/dockerfile/build
+
+COPY plunder.tar .
+
+RUN tar -P -xvf plunder.tar 
+
+WORKDIR /go/src/github.com/plunder-app/plunder
+
+RUN make
+
+#RUN /go/bin/plunder version


### PR DESCRIPTION
This adds the following:

- Move to go modules for building plunder
- Fix to `make build`
- `dockerfile/build/*.*` contains some additional testing for building `plunder` in a clean environment