### PR TITLE
Allow for override of the docker tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,8 @@ LDFLAGS=-ldflags "-X=main.Version=$(VERSION) -X=main.Build=$(BUILD) -s"
 
 #SRC = "."
 
-DOCKERTAG=latest
+DOCKERREPO ?= $(TARGET)
+DOCKERTAG ?= latest
 
 .PHONY: all build clean install uninstall fmt simplify check run lint vet
 
@@ -60,7 +61,7 @@ lint:
 docker:
 	@GOOS=$(TARGETOS) make build
 	@mv $(TARGET) ./dockerfile
-	@docker build -t $(TARGET):$(DOCKERTAG) ./dockerfile/
+	@docker build -t $(DOCKERREPO):$(DOCKERTAG) ./dockerfile/
 	@rm ./dockerfile/$(TARGET)
 	@echo New Docker image created
 


### PR DESCRIPTION
It may be useful to override the docker image tag. So add the DOCKERREPO
variable that will default to "plunder" but may be overriden via
environment variable. Similarly make the tag capable of being overriden.