### PR TITLE
Fixes to the boot configuration

### DIFF
--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -1,0 +1,3 @@
+module github.com/plunder-app/plunder/pkg
+
+go 1.12

--- a/pkg/services/deployments.go
+++ b/pkg/services/deployments.go
@@ -45,7 +45,7 @@ func rebuildConfiguration(updateConfig *DeploymentConfigurationFile) error {
 		// inMemipxeConfig is a custom configuration that is specific to the boot type [preseed/kickstart/vsphere] and is 00:11:22:33:44:55.cfg
 		var inMemBootConfig string
 
-		// imMemESXiKickstart is a custom configuraton specific to vSphere for it's kickstart
+		// imMemESXiKickstart is a custom configuration specific to vSphere for it's kickstart
 		var imMemESXiKickstart string
 
 		// We need to move all ":" to "-" to make life a little easier for filesystems and internet standards

--- a/pkg/services/server.go
+++ b/pkg/services/server.go
@@ -81,7 +81,10 @@ func (c *BootController) DeleteBootControllerConfig(configName string) error {
 	for i := range c.BootConfigs {
 		if c.BootConfigs[i].ConfigName == configName {
 			// Remove the mapping to an ISO path
-			isoMapper[c.BootConfigs[i].ISOPrefix] = ""
+			if isoMapper != nil {
+				// Ensure it is initialised before trying to remove boot config
+				isoMapper[c.BootConfigs[i].ISOPrefix] = ""
+			}
 			c.BootConfigs = append(c.BootConfigs[:i], c.BootConfigs[i+1:]...)
 			return nil
 		}

--- a/pkg/services/serverDHCP.go
+++ b/pkg/services/serverDHCP.go
@@ -115,7 +115,7 @@ func (h *DHCPSettings) ServeDHCP(p dhcp.Packet, msgType dhcp.MessageType, option
 					}
 
 					// if an entry doesnt exist then drop it to a default type, if not then it has its own specific
-					if httpPaths[fmt.Sprintf("%s.ipxe", dashMac)] == "" {
+					if httpPaths[fmt.Sprintf("/%s.ipxe", dashMac)] == "" {
 						h.Options[dhcp.OptionBootFileName] = []byte("http://" + h.IP.String() + "/" + deploymentType + ".ipxe")
 					} else {
 						h.Options[dhcp.OptionBootFileName] = []byte("http://" + h.IP.String() + "/" + dashMac + ".ipxe")


### PR DESCRIPTION
This ensures that boot configurations are simple to create:

```
pldrctl create boot -i pull-initrd.img -k BOOTy-linuxkit-kernel -c "console=tty0 console=ttys0 BOOTYSRC=http://192.168.0.95:3000/images/ubuntu.img BOOTYDST=/dev/sda" -n test
pldrctl create deployment -a 123123123 -m 00:50:56:a5:89:6e -c test
pldrctl describe deployment 00:50:56:a5:89:6e
```