### PR TITLE
This adds support for BOOTy as a deployment config

### DIFF
--- a/cmd/configGenerator.go
+++ b/cmd/configGenerator.go
@@ -104,12 +104,18 @@ var plunderDeploymentConfig = &cobra.Command{
 			Subnet:            "255.255.255.0",
 			Username:          "user",
 			Password:          "pass",
-			Packages:          "openssh-server",
+			Packages:          "openssh-server cloud-guest-utils",
 			RepositoryAddress: "192.168.0.1",
 			MirrorDirectory:   "/ubuntu",
 			SSHKeyPath:        "/home/deploy/.ssh/id_pub.rsa",
 			SSHKey:            "ssh-rsa AABBCCDDEE1122334455",
+			LVMRootName:       "/dev/ubuntu-vg/root",
+			DestinationDevice: "/dev/sda",
+			SourceImage:       "http://192.168.0.95/images/ubuntu.img",
 		}
+		// Addtional step to create the partition information
+		defaultPartition := 1
+		globalConfig.GrowPartition = &defaultPartition
 
 		// Create an example Host configuration
 		hostConfig := services.HostConfig{

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/kr/pty v1.1.8 // indirect
 	github.com/krolaw/dhcp4 v0.0.0-20190531080455-7b64900047ae // indirect
 	github.com/pkg/sftp v1.10.1 // indirect
+	github.com/plunder-app/BOOTy v0.0.0-20200506165408-19d2090683fe // indirect
 	github.com/plunder-app/plunder/pkg/apiserver v0.0.0-20191105152536-b5c505aaf830
 	github.com/plunder-app/plunder/pkg/certs v0.0.0-00010101000000-000000000000
 	github.com/plunder-app/plunder/pkg/parlay v0.0.0-20191105152536-b5c505aaf830
@@ -25,6 +26,7 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5
 	github.com/thebsdbox/go-tftp v0.0.0-20190329154032-a7263f18c49c // indirect
+	github.com/vishvananda/netlink v1.1.0 // indirect
 	github.com/whyrusleeping/go-tftp v0.0.0-20180830013254-3695fa5761ee // indirect
 	golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7 // indirect
 	golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a // indirect
@@ -36,4 +38,7 @@ replace (
 	github.com/plunder-app/plunder/pkg/certs => ./pkg/certs
 	github.com/plunder-app/plunder/pkg/services => ./pkg/services
 	github.com/plunder-app/plunder/pkg/ssh => ./pkg/ssh
+	github.com/plunder-app/plunder/pkg/utils => ./pkg/utils
+	github.com/plunder-app/BOOTy => ../../../github.com/thebsdbox/BOOTy
+
 )

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1 h1:VasscCm72135zRysgrJDKsntdmPN+OuU3+nnHYA9wyc=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
+github.com/plunder-app/BOOTy v0.0.0-20200506165408-19d2090683fe h1:UaS5HU5eeNd8ArNna0yf/nr/usHoQZsXfZUerj3lhmE=
+github.com/plunder-app/BOOTy v0.0.0-20200506165408-19d2090683fe/go.mod h1:EhhJilCAJNAXb/ZvNPPUb+VOnMF5F47KiSjJxQzBzNw=
 github.com/plunder-app/plunder/pkg/parlay v0.0.0-20191105152536-b5c505aaf830 h1:8z5GZZQUY+GBT+kOd8gKpD0lS1qrh9he7SmEDwQS4jg=
 github.com/plunder-app/plunder/pkg/parlay v0.0.0-20191105152536-b5c505aaf830/go.mod h1:5UuNaULcTUSFIkrbe+NA/ufh9iyUEtsKqmjlbl88AVw=
 github.com/plunder-app/plunder/pkg/parlay/parlaytypes v0.0.0-20191105152536-b5c505aaf830 h1:sbV3um7RoWCkSMCY0azjr5Dovv7Z9PnaozkWSpxFgG0=
@@ -93,6 +95,10 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/thebsdbox/go-tftp v0.0.0-20190329154032-a7263f18c49c h1:cYCrFUo78/407dxOlYw2g4pdm4Ly8RSPedsYB+z7h1s=
 github.com/thebsdbox/go-tftp v0.0.0-20190329154032-a7263f18c49c/go.mod h1:yXG6GIu/ptjkk0fd++y96R2cahlvxZr4LhMdf0j/L2Q=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
+github.com/vishvananda/netlink v1.1.0 h1:1iyaYNBLmP6L0220aDnYQpo1QEV4t4hJ+xEEhhJH8j0=
+github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
+github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df h1:OviZH7qLw/7ZovXvuNyL3XQl8UFofeikI1NW1Gypu7k=
+github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/whyrusleeping/go-tftp v0.0.0-20180830013254-3695fa5761ee h1:P2Wwq5QukiLY/I6+mc7NyLFX/atHAj6pGwiVu6fld98=
 github.com/whyrusleeping/go-tftp v0.0.0-20180830013254-3695fa5761ee/go.mod h1:ZemSN4DPuG1ppDttxnu45zl8BenKT9xSjMyapUd+Dd0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
@@ -112,6 +118,7 @@ golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/p
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190530182044-ad28b68e88f1 h1:R4dVlxdmKenVdMRS/tTspEpSTRWINYrHD8ySIU9yCIU=
 golang.org/x/sys v0.0.0-20190530182044-ad28b68e88f1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190606203320-7fc4e5ec1444/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a h1:aYOabOQFp6Vj6W1F80affTUvO9UxmJRx8K0gsfABByQ=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pkg/services/serverDHCP.go
+++ b/pkg/services/serverDHCP.go
@@ -206,6 +206,9 @@ func (c *BootController) GetUnLeased() *[]Lease {
 
 // DelUnLeased - This will retrieve all of the un-allocated leases from the boot controller
 func (c *BootController) DelUnLeased(mac string) {
+	if c == nil || c.handler == nil {
+		return
+	}
 	if len(c.handler.UnLeased) == 0 {
 		return
 	}

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -166,6 +166,18 @@ func (c *BootController) StartServices(deployment []byte) error {
 			}
 		}
 	}
+
+	go func() {
+
+		fs := http.FileServer(http.Dir("./images"))
+		http.Handle("/images/", http.StripPrefix("/images/", fs))
+		log.Println("Plunder OS Image Services --> Starting HTTP")
+		err := http.ListenAndServe(":3000", nil)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}()
+
 	// everything has been started correctly
 	return nil
 }

--- a/pkg/services/templateBOOTy.go
+++ b/pkg/services/templateBOOTy.go
@@ -1,0 +1,40 @@
+package services
+
+import (
+	"encoding/json"
+	"net"
+
+	"github.com/plunder-app/BOOTy/pkg/plunderclient/types"
+	"github.com/vishvananda/netlink"
+)
+
+//BuildBOOTYconfig - Creates a new presseed configuration using the passed data
+func (config *HostConfig) BuildBOOTYconfig() string {
+	a := types.BootyConfig{}
+	a.Action = types.WriteImage
+	// Parse the strings
+	subnet := net.ParseIP(config.Subnet)
+	ip := net.ParseIP(config.IPAddress)
+
+	// Change into a cidr
+	cidr := net.IPNet{
+		IP:   ip,
+		Mask: subnet.DefaultMask(),
+	}
+	addr, _ := netlink.ParseAddr(cidr.String())
+
+	// Set configuration
+	if addr != nil {
+		a.Address = addr.String()
+		a.Gateway = config.Gateway
+	}
+
+	a.DestinationDevice = config.DestinationDevice
+	a.SourceImage = config.SourceImage
+	a.GrowPartition = *config.GrowPartition
+	a.LVMRootName = config.LVMRootName
+	a.DropToShell = *config.ShellOnFail
+	a.NameServer = config.NameServer
+	b, _ := json.Marshal(a)
+	return string(b)
+}

--- a/pkg/services/templatePreseed.go
+++ b/pkg/services/templatePreseed.go
@@ -51,6 +51,163 @@ d-i netcfg/get_domain string internal
 
 d-i netcfg/hostname string %s`
 
+const preseedLVMDisk2 = `
+d-i partman-auto/method string lvm
+
+# If one of the disks that are going to be automatically partitioned
+# contains an old LVM configuration, the user will normally receive a
+# warning. This can be preseeded away...
+d-i partman-lvm/device_remove_lvm boolean true
+# The same applies to pre-existing software RAID array:
+d-i partman-md/device_remove_md boolean true
+# And the same goes for the confirmation to write the lvm partitions.
+d-i partman-lvm/confirm boolean true
+
+# You can choose one of the three predefined partitioning recipes:
+# - atomic: all files in one partition
+# - home:   separate /home partition
+# - multi:  separate /home, /usr, /var, and /tmp partitions
+d-i partman-auto/choose_recipe select atomic
+
+# Or provide a recipe of your own...
+# If you have a way to get a recipe file into the d-i environment, you can
+# just point at it.
+#d-i partman-auto/expert_recipe_file string /hd-media/recipe
+
+# If not, you can put an entire recipe into the preconfiguration file in one
+# (logical) line. This example creates a small /boot partition, suitable
+# swap, and uses the rest of the space for the root partition:
+#d-i partman-auto/expert_recipe string                         \
+#      boot-root ::                                            \
+#              40 50 100 ext3                                  \
+#                      $primary{ } $bootable{ }                \
+#                      method{ format } format{ }              \
+#                      use_filesystem{ } filesystem{ ext3 }    \
+#                      mountpoint{ /boot }                     \
+#              .                                               \
+#              500 10000 1000000000 ext3                       \
+#                      method{ format } format{ }              \
+#                      use_filesystem{ } filesystem{ ext3 }    \
+#                      mountpoint{ / }                         \
+#              .                                               \
+#              64 512 300% linux-swap                          \
+#                      method{ swap } format{ }                \
+#              .
+
+# The full recipe format is documented in the file partman-auto-recipe.txt
+# included in the 'debian-installer' package or available from D-I source
+# repository. This also documents how to specify settings such as file
+# system labels, volume group names and which physical devices to include
+# in a volume group.
+
+# This makes partman automatically partition without confirmation, provided
+# that you told it what to do using one of the methods above.
+d-i partman-partitioning/confirm_write_new_label boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+
+## Partitioning using RAID
+# The method should be set to "raid".
+#d-i partman-auto/method string raid
+# Specify the disks to be partitioned. They will all get the same layout,
+# so this will only work if the disks are the same size.
+#d-i partman-auto/disk string /dev/sda /dev/sdb
+
+# Next you need to specify the physical partitions that will be used. 
+#d-i partman-auto/expert_recipe string \
+#      multiraid ::                                         \
+#              1000 5000 4000 raid                          \
+#                      $primary{ } method{ raid }           \
+#              .                                            \
+#              64 512 300% raid                             \
+#                      method{ raid }                       \
+#              .                                            \
+#              500 10000 1000000000 raid                    \
+#                      method{ raid }                       \
+#              .
+
+# Last you need to specify how the previously defined partitions will be
+# used in the RAID setup. Remember to use the correct partition numbers
+# for logical partitions. RAID levels 0, 1, 5, 6 and 10 are supported;
+# devices are separated using "#".
+# Parameters are:
+# <raidtype> <devcount> <sparecount> <fstype> <mountpoint> \
+#          <devices> <sparedevices>
+
+#d-i partman-auto-raid/recipe string \
+#    1 2 0 ext3 /                    \
+#          /dev/sda1#/dev/sdb1       \
+#    .                               \
+#    1 2 0 swap -                    \
+#          /dev/sda5#/dev/sdb5       \
+#    .                               \
+#    0 2 0 ext3 /home                \
+#          /dev/sda6#/dev/sdb6       \
+#    .
+
+# For additional information see the file partman-auto-raid-recipe.txt
+# included in the 'debian-installer' package or available from D-I source
+# repository.
+
+# This makes partman automatically partition without confirmation.
+d-i partman-md/confirm boolean true
+d-i partman-partitioning/confirm_write_new_label boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+d-i partman-basicfilesystems/no_swap boolean false
+`
+
+const preseedLVMDisk = `
+d-i partman-auto/method string lvm
+
+# If one of the disks that are going to be automatically partitioned
+# contains an old LVM configuration, the user will normally receive a
+# warning. This can be preseeded away...
+
+d-i partman-lvm/device_remove_lvm boolean true
+
+# The same applies to pre-existing software RAID array:
+d-i partman-md/device_remove_md boolean true
+
+# And the same goes for the confirmation to write the lvm partitions.
+d-i partman-lvm/confirm boolean true
+
+# You can choose one of the three predefined partitioning recipes:
+# - atomic: all files in one partition
+# - home:   separate /home partition
+# - multi:  separate /home, /usr, /var, and /tmp partitions
+d-i partman-auto/choose_recipe select atomic
+
+# This makes partman automatically partition without confirmation, provided
+# that you told it what to do using one of the methods above.
+d-i partman-partitioning/confirm_write_new_label boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+
+
+# This makes partman automatically partition without confirmation.
+d-i partman-md/confirm boolean true
+# LVM confifirmation
+d-i partman-lvm/confirm boolean true
+d-i partman-lvm/confirm_nooverwrite boolean true
+d-i partman-partitioning/confirm_write_new_label boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+d-i partman-basicfilesystems/no_swap boolean false
+
+### Finishing up the installation
+d-i finish-install/reboot_in_progress note
+d-i cdrom-detect/eject boolean true
+
+### Preseeding other packages
+popularity-contest popularity-contest/participate boolean false
+
+`
+
 const preseedDisk = `
 ### Partitions
 d-i partman/mount_style select label
@@ -208,6 +365,9 @@ func (config *HostConfig) BuildPreeSeedConfig() string {
 	} else {
 		parsedDisk = preseedDisk + noswap
 	}
+
+	parsedDisk = preseedLVMDisk
+
 	parsedNet := fmt.Sprintf(preseedNet, config.Adapter, config.Gateway, config.IPAddress, config.NameServer, config.Subnet, config.ServerName)
 	parsedPkg := fmt.Sprintf(preseedPkg, config.RepositoryAddress, config.MirrorDirectory, config.RepositoryAddress, config.MirrorDirectory, config.Packages)
 	parsedCmd := fmt.Sprintf(preseedCmd, config.Username, key, config.Username, config.Username, config.Username, config.Username, config.Username)

--- a/pkg/services/templateUtils.go
+++ b/pkg/services/templateUtils.go
@@ -39,8 +39,8 @@ func (c *HostConfig) parseSSH() error {
 	return nil
 }
 
-// PopulateConfiguration - This will read a deployment configuration and attempt to fill any missing fields from the global config
-func (c *HostConfig) PopulateConfiguration(globalConfig HostConfig) {
+// PopulateFromGlobalConfiguration - This will read a deployment configuration and attempt to fill any missing fields from the global config
+func (c *HostConfig) PopulateFromGlobalConfiguration(globalConfig HostConfig) {
 	// NETWORK CONFIGURATION
 
 	// Inherit the global Gateway
@@ -96,5 +96,27 @@ func (c *HostConfig) PopulateConfiguration(globalConfig HostConfig) {
 	// Inherit the global package selection
 	if c.Packages == "" {
 		c.Packages = globalConfig.Packages
+	}
+
+	// BOOTy configuration (TODO CAN NOT LEAVE THIS HERE)
+	if c.GrowPartition == nil && globalConfig.GrowPartition != nil {
+		c.GrowPartition = globalConfig.GrowPartition
+	}
+
+	if c.LVMRootName == "" {
+		c.LVMRootName = globalConfig.LVMRootName
+	}
+
+	if c.DestinationDevice == "" {
+		c.DestinationDevice = globalConfig.DestinationDevice
+	}
+
+	if c.SourceImage == "" {
+		c.SourceImage = globalConfig.SourceImage
+	}
+
+	// TODO
+	if c.ShellOnFail == nil && globalConfig.ShellOnFail != nil {
+		c.ShellOnFail = globalConfig.ShellOnFail
 	}
 }

--- a/pkg/services/types.go
+++ b/pkg/services/types.go
@@ -80,6 +80,7 @@ type HostConfig struct {
 	Username string `json:"username,omitempty"`
 	Password string `json:"password,omitempty"`
 
+	// RepositoryAddress is required for pre-seed / kickstart
 	RepositoryAddress string `json:"repoaddress,omitempty"`
 	// MirrorDirectory is an Ubuntu specific config
 	MirrorDirectory string `json:"mirrordir,omitempty"`
@@ -91,4 +92,18 @@ type HostConfig struct {
 
 	// Packages to be installed
 	Packages string `json:"packages,omitempty"`
+
+	// OS Image provisioning
+	// Write image to disk from remote address
+	SourceImage       string `json:"sourceImage,omitempty"`
+	DestinationDevice string `json:"destinationDevice,omitempty"`
+
+	// Post tasks - Once the image has been deployed
+
+	// Volume modifications (LVM2)
+	GrowPartition *int   `json:"growPartition,omitempty"`
+	LVMRootName   string `json:"lvmRootName,omitempty"`
+
+	// Troubleshooting
+	ShellOnFail *bool `json:"shellOnFail,omitempty"`
 }

--- a/pkg/utils/ipxe.go
+++ b/pkg/utils/ipxe.go
@@ -94,6 +94,19 @@ boot
 	return iPXEHeader + buildScript
 }
 
+// IPXEBOOTy - This will build an iPXE boot script for the BOOTy boot loader
+func IPXEBOOTy(webserverAddress, kernel, initrd, cmdline string) string {
+	script := `
+kernel http://%s/%s BOOTYURL=http://%s %s
+initrd http://%s/%s
+boot
+`
+	// Replace the addresses inline
+	buildScript := fmt.Sprintf(script, webserverAddress, kernel, webserverAddress, cmdline, webserverAddress, initrd)
+
+	return iPXEHeader + buildScript
+}
+
 // IPXEAnyBoot - This will build an iPXE boot script for anything wanting to PXE boot
 func IPXEAnyBoot(webserverAddress string, kernel, initrd, cmdline string) string {
 	script := `


### PR DESCRIPTION
Creating a configuration of type BOOTy is now supported.

This adds in all of the basics of using the OS Image provisioner as a configuration choice