### PR TITLE
This adds the flexability of having multiple boot configuration using…

### DIFF
--- a/cmd/configGenerator.go
+++ b/cmd/configGenerator.go
@@ -75,7 +75,8 @@ var plunderServerConfig = &cobra.Command{
 			Kernel:     "/kernelPath",
 			Initrd:     "/initPath",
 			Cmdline:    "cmd=options",
-			ConfigName: "default",
+			ConfigName: "demo config",
+			ConfigType: "default",
 		}
 
 		detectServerConfig()
@@ -125,7 +126,7 @@ var plunderDeploymentConfig = &cobra.Command{
 		hostDeployConfig := services.DeploymentConfig{
 			MAC:        "00:11:22:33:44:55",
 			ConfigHost: hostConfig,
-			ConfigName: "default",
+			//ConfigName: "default",
 		}
 
 		configuration := &services.DeploymentConfigurationFile{

--- a/go.mod
+++ b/go.mod
@@ -15,14 +15,14 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/sftp v1.11.0 // indirect
 	github.com/plunder-app/BOOTy v0.0.0-20200513203223-f43f6ea742c4 // indirect
-	github.com/plunder-app/plunder/pkg/apiserver v0.0.0-20200513203243-eccb418a5255
-	github.com/plunder-app/plunder/pkg/certs v0.0.0-20200513203243-eccb418a5255
-	github.com/plunder-app/plunder/pkg/parlay v0.0.0-20200513203243-eccb418a5255
-	github.com/plunder-app/plunder/pkg/parlay/parlaytypes v0.0.0-20200513203243-eccb418a5255
-	github.com/plunder-app/plunder/pkg/plunderlogging v0.0.0-20200513203243-eccb418a5255 // indirect
-	github.com/plunder-app/plunder/pkg/services v0.0.0-20200513203243-eccb418a5255
-	github.com/plunder-app/plunder/pkg/ssh v0.0.0-20200513203243-eccb418a5255
-	github.com/plunder-app/plunder/pkg/utils v0.0.0-20200513203243-eccb418a5255
+	github.com/plunder-app/plunder/pkg/apiserver v0.0.0-20200514155151-dfdcaab2e5cd
+	github.com/plunder-app/plunder/pkg/certs v0.0.0-20200514155151-dfdcaab2e5cd
+	github.com/plunder-app/plunder/pkg/parlay v0.0.0-20200514155151-dfdcaab2e5cd
+	github.com/plunder-app/plunder/pkg/parlay/parlaytypes v0.0.0-20200514155151-dfdcaab2e5cd
+	github.com/plunder-app/plunder/pkg/plunderlogging v0.0.0-20200514155151-dfdcaab2e5cd // indirect
+	github.com/plunder-app/plunder/pkg/services v0.0.0-20200514155151-dfdcaab2e5cd
+	github.com/plunder-app/plunder/pkg/ssh v0.0.0-20200514155151-dfdcaab2e5cd
+	github.com/plunder-app/plunder/pkg/utils v0.0.0-20200514155151-dfdcaab2e5cd
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5 // indirect
@@ -36,9 +36,9 @@ require (
 replace (
 	github.com/plunder-app/plunder/pkg/apiserver => ./pkg/apiserver
 	github.com/plunder-app/plunder/pkg/certs => ./pkg/certs
+	github.com/plunder-app/plunder/pkg/parlay => ./pkg/parlay
 	github.com/plunder-app/plunder/pkg/services => ./pkg/services
 	github.com/plunder-app/plunder/pkg/ssh => ./pkg/ssh
 	github.com/plunder-app/plunder/pkg/utils => ./pkg/utils
-	github.com/plunder-app/plunder/pkg/parlay => ./pkg/parlay
 
 )

--- a/go.sum
+++ b/go.sum
@@ -117,8 +117,16 @@ github.com/plunder-app/plunder/pkg/parlay v0.0.0-20200513203243-eccb418a5255 h1:
 github.com/plunder-app/plunder/pkg/parlay v0.0.0-20200513203243-eccb418a5255/go.mod h1:5UuNaULcTUSFIkrbe+NA/ufh9iyUEtsKqmjlbl88AVw=
 github.com/plunder-app/plunder/pkg/parlay/parlaytypes v0.0.0-20200513203243-eccb418a5255 h1:765Djvc0TdpwZFlEmyq1ruUPx69klzHQOMAMCK1KJZM=
 github.com/plunder-app/plunder/pkg/parlay/parlaytypes v0.0.0-20200513203243-eccb418a5255/go.mod h1:QtxXmGRkwdtiiH03oveOPcYXucOv/FxJq2a170aXkxg=
+github.com/plunder-app/plunder/pkg/parlay/parlaytypes v0.0.0-20200514154439-933b7120d270 h1:p59jcYFaRO6LOJz/OAcdPNSlbgl1QPH4cmlFs69BZ6g=
+github.com/plunder-app/plunder/pkg/parlay/parlaytypes v0.0.0-20200514154439-933b7120d270/go.mod h1:QtxXmGRkwdtiiH03oveOPcYXucOv/FxJq2a170aXkxg=
+github.com/plunder-app/plunder/pkg/parlay/parlaytypes v0.0.0-20200514155151-dfdcaab2e5cd h1:CA9lXqJAJxwA/NGepdfE/hQapGplV4CNNal3eZ9C/k0=
+github.com/plunder-app/plunder/pkg/parlay/parlaytypes v0.0.0-20200514155151-dfdcaab2e5cd/go.mod h1:QtxXmGRkwdtiiH03oveOPcYXucOv/FxJq2a170aXkxg=
 github.com/plunder-app/plunder/pkg/plunderlogging v0.0.0-20200513203243-eccb418a5255 h1:gzlti8QQwa02qAGlFktceQucT4HZUZFWIm6h4b03JBo=
 github.com/plunder-app/plunder/pkg/plunderlogging v0.0.0-20200513203243-eccb418a5255/go.mod h1:ketI5Vxh8nmxwiWnS644ZaEwVt9M/bpP6ISaFeWpcS0=
+github.com/plunder-app/plunder/pkg/plunderlogging v0.0.0-20200514154439-933b7120d270 h1:abUhCq54uc/4Q/ApJMGtWmsSGSLJcni5P8VXyrLZ49o=
+github.com/plunder-app/plunder/pkg/plunderlogging v0.0.0-20200514154439-933b7120d270/go.mod h1:ketI5Vxh8nmxwiWnS644ZaEwVt9M/bpP6ISaFeWpcS0=
+github.com/plunder-app/plunder/pkg/plunderlogging v0.0.0-20200514155151-dfdcaab2e5cd h1:luKDb4GvbZlnythTGjypGW8EdCyRSSXwUvbr+ZrB2zU=
+github.com/plunder-app/plunder/pkg/plunderlogging v0.0.0-20200514155151-dfdcaab2e5cd/go.mod h1:ketI5Vxh8nmxwiWnS644ZaEwVt9M/bpP6ISaFeWpcS0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=

--- a/pkg/apiserver/types.go
+++ b/pkg/apiserver/types.go
@@ -4,7 +4,7 @@ import "encoding/json"
 
 //Response - This is the wrapper for responses back to a client, if any errors are created then the payload isn't guarenteed
 type Response struct {
-	Warning string `json:"warmomg,omitempty"` // when it maybe worked
+	Warning string `json:"warning,omitempty"` // when it maybe worked
 	Error   string `json:"error,omitempty"`   // when it goes wrong
 	Success string `json:"success,omitempty"` // when it goes correct
 

--- a/pkg/parlay/handler.go
+++ b/pkg/parlay/handler.go
@@ -103,7 +103,6 @@ func getParlay(w http.ResponseWriter, r *http.Request) {
 	logs, err := GetTargetLogs(target)
 	// If the deployment exists then process the POST data
 	if err != nil {
-
 		// RETREIVE the deployment Logs (TODO)
 		rsp.Warning = "Error reading Parlay Logs"
 		rsp.Error = err.Error()

--- a/pkg/services/deployments.go
+++ b/pkg/services/deployments.go
@@ -81,7 +81,7 @@ func rebuildConfiguration(updateConfig *DeploymentConfigurationFile) error {
 		}
 
 		// Look for understood config types
-		switch updateConfig.Configs[i].ConfigName {
+		switch updateConfig.Configs[i].ConfigBoot.ConfigType {
 		case "preseed":
 			inMemipxeConfig = utils.IPXEPreeseed(httpAddress, bootConfig.Kernel, bootConfig.Initrd, bootConfig.Cmdline)
 			log.Debugf("Generating preseed ipxeConfig for [%s]", dashMac)

--- a/pkg/services/handler.go
+++ b/pkg/services/handler.go
@@ -162,7 +162,18 @@ func postBootConfig(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			rsp.Warning = "Error updating Server Configuration"
 			rsp.Error = err.Error()
+
 		} else {
+			for x := range Controller.BootConfigs {
+				if Controller.BootConfigs[x].ConfigName == newBoot.ConfigName {
+					// Found a duplicate
+					w.Header().Set("Content-Type", "application/json")
+					rsp.Warning = "Error duplicate Server Configuration"
+					rsp.Error = fmt.Sprintf("Boot Configuration [%s] already exists", Controller.BootConfigs[x].ConfigName)
+					json.NewEncoder(w).Encode(rsp)
+					return
+				}
+			}
 			// Add the Boot configuration to the controller
 			Controller.BootConfigs = append(Controller.BootConfigs, newBoot)
 			// Parse the boot configuration (preload ISOs etc.)

--- a/pkg/services/serverHTTP.go
+++ b/pkg/services/serverHTTP.go
@@ -20,7 +20,7 @@ var serveMux *http.ServeMux
 func (c *BootController) generateBootTypeHanders() {
 
 	// Find the default configuration
-	defaultConfig := findBootConfigForName("default")
+	defaultConfig := findBootConfigForType("default")
 	if defaultConfig != nil {
 		defaultBoot = utils.IPXEPreeseed(*c.HTTPAddress, defaultConfig.Kernel, defaultConfig.Initrd, defaultConfig.Cmdline)
 	} else {
@@ -28,20 +28,20 @@ func (c *BootController) generateBootTypeHanders() {
 	}
 
 	// If a preeseed configuration has been configured then add it, and create a HTTP endpoint
-	preeseedConfig := findBootConfigForName("preseed")
+	preeseedConfig := findBootConfigForType("preseed")
 	if preeseedConfig != nil {
 		preseed = utils.IPXEPreeseed(*c.HTTPAddress, preeseedConfig.Kernel, preeseedConfig.Initrd, preeseedConfig.Cmdline)
 
 	}
 
 	// If a kickstart configuration has been configured then add it, and create a HTTP endpoint
-	kickstartConfig := findBootConfigForName("kickstart")
+	kickstartConfig := findBootConfigForType("kickstart")
 	if kickstartConfig != nil {
 		kickstart = utils.IPXEPreeseed(*c.HTTPAddress, kickstartConfig.Kernel, kickstartConfig.Initrd, kickstartConfig.Cmdline)
 	}
 
 	// If a vsphereConfig configuration has been configured then add it, and create a HTTP endpoint
-	vsphereConfig := findBootConfigForName("vsphere")
+	vsphereConfig := findBootConfigForType("vsphere")
 	if vsphereConfig != nil {
 		vsphere = utils.IPXEVSphere(*c.HTTPAddress, vsphereConfig.Kernel, vsphereConfig.Cmdline)
 	}

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -39,11 +39,11 @@ func findBootConfigForDeployment(deployment DeploymentConfig) *BootConfig {
 }
 
 // find BootConfig will look through a Boot controller for a booting configuration identified through a configuration name
-func findBootConfigForName(configName string) *BootConfig {
+func findBootConfigForType(ConfigType string) *BootConfig {
 
 	// Find a matching controller configuration to return
 	for i := range Controller.BootConfigs {
-		if Controller.BootConfigs[i].ConfigName == configName {
+		if Controller.BootConfigs[i].ConfigType == ConfigType {
 			return &Controller.BootConfigs[i]
 		}
 	}
@@ -53,9 +53,10 @@ func findBootConfigForName(configName string) *BootConfig {
 }
 
 // find BootConfig will look through a Boot controller for a booting configuration identified through a configuration name
-func (c *BootController) setBootConfig(configName, kernel, initrd, cmdline string) {
+func (c *BootController) setBootConfig(configName, configType, kernel, initrd, cmdline string) {
 	newConfig := &BootConfig{
 		ConfigName: configName,
+		ConfigType: configType,
 		Kernel:     kernel,
 		Initrd:     initrd,
 		Cmdline:    cmdline,

--- a/pkg/services/types.go
+++ b/pkg/services/types.go
@@ -37,6 +37,7 @@ type dhcpConfig struct {
 // BootConfig defines a named configuration for booting
 type BootConfig struct {
 	ConfigName string `json:"configName"`
+	ConfigType string `json:"configType"`
 
 	// iPXE file settings - exported
 	Kernel  string `json:"kernelPath"`


### PR DESCRIPTION
… types.

```
> pldrctl get boot                                                                                                                                                                                    ~
Config Name  Config Type  Kernel Path                                          Initrd Path                                              Command Line
default                   /kernelPath                                          /initPath                                                cmd=options
pull         booty        kernel                                               initramfs.cpio.gz                                        console=tty0 BOOTYURL=http://172.16.1.1/
push         booty        kernel                                               initramfs.cpio.gz                                        console=tty0 BOOTYURL=http://172.16.1.3/
install      preseed      kernel                                               initramfs.cpio.gz                                        console=ttyS0
preseed      preseed      ubuntu/install/netboot/ubuntu-installer/amd64/linux  ubuntu/install/netboot/ubuntu-installer/amd64/initrd.gz  
```