### PR TITLE
Adds in a bootyserver

### DIFF
--- a/cmd/configGenerator.go
+++ b/cmd/configGenerator.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/ghodss/yaml"
+	booty "github.com/plunder-app/BOOTy/pkg/plunderclient/types"
 	"github.com/plunder-app/plunder/pkg/apiserver"
 	"github.com/plunder-app/plunder/pkg/certs"
 	"github.com/plunder-app/plunder/pkg/parlay/parlaytypes"
@@ -98,11 +99,12 @@ var plunderDeploymentConfig = &cobra.Command{
 		log.SetLevel(log.Level(logLevel))
 		// Create an example Global configuration
 		globalConfig := services.HostConfig{
-			Gateway:           "192.168.0.1",
-			NTPServer:         "192.168.0.1",
-			NameServer:        "192.168.0.1",
-			Adapter:           "ens192",
-			Subnet:            "255.255.255.0",
+			Gateway:    "192.168.0.1",
+			NTPServer:  "192.168.0.1",
+			NameServer: "192.168.0.1",
+			Adapter:    "ens192",
+			Subnet:     "255.255.255.0",
+			// OS Provision
 			Username:          "user",
 			Password:          "pass",
 			Packages:          "openssh-server cloud-guest-utils",
@@ -110,10 +112,19 @@ var plunderDeploymentConfig = &cobra.Command{
 			MirrorDirectory:   "/ubuntu",
 			SSHKeyPath:        "/home/deploy/.ssh/id_pub.rsa",
 			SSHKey:            "ssh-rsa AABBCCDDEE1122334455",
-			LVMRootName:       "/dev/ubuntu-vg/root",
-			DestinationDevice: "/dev/sda",
-			SourceImage:       "http://192.168.0.95/images/ubuntu.img",
+			// BOOTy
+			BOOTYAction:        booty.ReadImage,
+			LVMRootName:        "/dev/ubuntu-vg/root",
+			DestinationDevice:  "/dev/sda",
+			DestinationAddress: "http://192.168.0.1/image",
+			SourceImage:        "http://192.168.0.1/images/ubuntu.img",
+			SourceDevice:       "/dev/sda",
 		}
+
+		// Set compressed pointer
+		compressed := false
+		globalConfig.Compressed = &compressed
+
 		// Addtional step to create the partition information
 		defaultPartition := 1
 		globalConfig.GrowPartition = &defaultPartition
@@ -322,11 +333,12 @@ func detectServerConfig() error {
 	*services.Controller.PXEFileName = "undionly.kpxe"
 
 	// DHCP Settings
-	services.Controller.DHCPConfig.DHCPAddress = &nicAddr
-	services.Controller.DHCPConfig.DHCPGateway = &nicAddr
-	services.Controller.DHCPConfig.DHCPDNS = &nicAddr
-	*services.Controller.DHCPConfig.DHCPLeasePool = 20
-	*services.Controller.DHCPConfig.DHCPStartAddress = ip.String()
+	services.Controller.DHCPConfig.DHCPAddress = nicAddr
+	services.Controller.DHCPConfig.DHCPSubnet = "255.255.255.0"
+	services.Controller.DHCPConfig.DHCPGateway = nicAddr
+	services.Controller.DHCPConfig.DHCPDNS = nicAddr
+	services.Controller.DHCPConfig.DHCPLeasePool = 20
+	services.Controller.DHCPConfig.DHCPStartAddress = ip.String()
 
 	return nil
 }

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -37,11 +37,11 @@ func init() {
 	services.Controller.PXEFileName = PlunderServer.Flags().String("iPXEPath", "undionly.kpxe", "Path to an iPXE bootloader")
 
 	// DHCP Settings
-	services.Controller.DHCPConfig.DHCPAddress = PlunderServer.Flags().String("addressDHCP", "", "Address to advertise leases from, ideally will be the IP address of --adapter")
-	services.Controller.DHCPConfig.DHCPGateway = PlunderServer.Flags().String("gateway", "", "Address of Gateway to use, if blank will default to [addressDHCP]")
-	services.Controller.DHCPConfig.DHCPDNS = PlunderServer.Flags().String("dns", "", "Address of DNS to use, if blank will default to [addressDHCP]")
-	services.Controller.DHCPConfig.DHCPLeasePool = PlunderServer.Flags().Int("leasecount", 20, "Amount of leases to advertise")
-	services.Controller.DHCPConfig.DHCPStartAddress = PlunderServer.Flags().String("startAddress", "", "Start advertised address [REQUIRED]")
+	PlunderServer.Flags().StringVar(&services.Controller.DHCPConfig.DHCPAddress, "addressDHCP", "", "Address to advertise leases from, ideally will be the IP address of --adapter")
+	PlunderServer.Flags().StringVar(&services.Controller.DHCPConfig.DHCPGateway, "gateway", "", "Address of Gateway to use, if blank will default to [addressDHCP]")
+	PlunderServer.Flags().StringVar(&services.Controller.DHCPConfig.DHCPDNS, "dns", "", "Address of DNS to use, if blank will default to [addressDHCP]")
+	PlunderServer.Flags().IntVar(&services.Controller.DHCPConfig.DHCPLeasePool, "leasecount", 20, "Amount of leases to advertise")
+	PlunderServer.Flags().StringVar(&services.Controller.DHCPConfig.DHCPStartAddress, "startAddress", "", "Start advertised address [REQUIRED]")
 
 	//HTTP Settings
 	defaultKernel = PlunderServer.Flags().String("kernel", "", "Path to a kernel to set as the *default* kernel")
@@ -113,11 +113,11 @@ var PlunderServer = &cobra.Command{
 		}
 
 		// If we've enabled DHCP, then we need to ensure a start address for the range is populated
-		if *services.Controller.EnableDHCP && *services.Controller.DHCPConfig.DHCPStartAddress == "" {
+		if *services.Controller.EnableDHCP && services.Controller.DHCPConfig.DHCPStartAddress == "" {
 			log.Fatalln("A DHCP Start address is required")
 		}
 
-		if *services.Controller.DHCPConfig.DHCPLeasePool == 0 {
+		if services.Controller.DHCPConfig.DHCPLeasePool == 0 {
 			log.Fatalln("At least one available lease is required")
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/mattn/go-colorable v0.1.6 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/sftp v1.11.0 // indirect
-	github.com/plunder-app/BOOTy v0.0.0-20200513203223-f43f6ea742c4 // indirect
+	github.com/plunder-app/BOOTy v0.0.0-20200513203223-f43f6ea742c4
 	github.com/plunder-app/plunder/pkg/apiserver v0.0.0-20200514155151-dfdcaab2e5cd
 	github.com/plunder-app/plunder/pkg/certs v0.0.0-20200514155151-dfdcaab2e5cd
 	github.com/plunder-app/plunder/pkg/parlay v0.0.0-20200514155151-dfdcaab2e5cd
@@ -40,5 +40,5 @@ replace (
 	github.com/plunder-app/plunder/pkg/services => ./pkg/services
 	github.com/plunder-app/plunder/pkg/ssh => ./pkg/ssh
 	github.com/plunder-app/plunder/pkg/utils => ./pkg/utils
-
+github.com/plunder-app/BOOTy => ../../plunder-app/BOOTy
 )

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,7 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/digineo/go-dhclient v1.0.2/go.mod h1:DPvyqGEW8irJvp2lrnGfQWpjj6VidXX9STLBTfNing4=
+github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=

--- a/pkg/services/deployments.go
+++ b/pkg/services/deployments.go
@@ -84,27 +84,27 @@ func rebuildConfiguration(updateConfig *DeploymentConfigurationFile) error {
 		switch updateConfig.Configs[i].ConfigBoot.ConfigType {
 		case "preseed":
 			inMemipxeConfig = utils.IPXEPreeseed(httpAddress, bootConfig.Kernel, bootConfig.Initrd, bootConfig.Cmdline)
-			log.Debugf("Generating preseed ipxeConfig for [%s]", dashMac)
+			log.Debugf("Generating preseed ipxeConfig for configName [%s]", dashMac)
 			inMemBootConfig = updateConfig.Configs[i].ConfigHost.BuildPreeSeedConfig()
 
 		case "kickstart":
 			inMemipxeConfig = utils.IPXEKickstart(httpAddress, bootConfig.Kernel, bootConfig.Initrd, bootConfig.Cmdline)
-			log.Debugf("Generating kickstart ipxeConfig for [%s]", dashMac)
+			log.Debugf("Generating kickstart ipxeConfig for configName [%s]", dashMac)
 			inMemBootConfig = updateConfig.Configs[i].ConfigHost.BuildKickStartConfig()
 
 		case "vsphere":
 			inMemipxeConfig = utils.IPXEVSphere(httpAddress, bootConfig.Kernel, bootConfig.Cmdline)
-			log.Debugf("Generating vsphere ipxeConfig for [%s]", dashMac)
+			log.Debugf("Generating vsphere ipxeConfig for configName [%s]", dashMac)
 			inMemBootConfig = updateConfig.Configs[i].ConfigHost.BuildESXiConfig()
 			imMemESXiKickstart = updateConfig.Configs[i].ConfigHost.BuildESXiKickStart()
 
 		case "booty":
 			inMemipxeConfig = utils.IPXEBOOTy(httpAddress, bootConfig.Kernel, bootConfig.Initrd, bootConfig.Cmdline)
-			log.Debugf("Generating booty ipxeConfig for [%s]", dashMac)
+			log.Debugf("Generating booty ipxeConfig for configName [%s]", dashMac)
 			inMemBOOTyConfig = updateConfig.Configs[i].ConfigHost.BuildBOOTYconfig()
 
 		default:
-			log.Debugf("Building configuration for configName [%s]", updateConfig.Configs[i].ConfigBoot.ConfigName)
+			log.Debugf("Generating default ipxeConfig for configName [%s]", updateConfig.Configs[i].ConfigBoot.ConfigName)
 			inMemipxeConfig = utils.IPXEAnyBoot(httpAddress, bootConfig.Kernel, bootConfig.Initrd, bootConfig.Cmdline)
 		}
 

--- a/pkg/services/handler.go
+++ b/pkg/services/handler.go
@@ -174,15 +174,26 @@ func postBootConfig(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 			}
-			// Add the Boot configuration to the controller
-			Controller.BootConfigs = append(Controller.BootConfigs, newBoot)
-			// Parse the boot configuration (preload ISOs etc.)
-			err = Controller.ParseBootController()
+			// // Parse the boot configuration (preload ISOs etc.)
+			err = newBoot.Parse()
+			// err = Controller.ParseBootController()
 			if err != nil {
 				w.Header().Set("Content-Type", "application/json")
 				rsp.Warning = "Error updating Server Configuration"
 				rsp.Error = err.Error()
+			} else {
+				// Add the Boot configuration to the controller
+				Controller.BootConfigs = append(Controller.BootConfigs, newBoot)
+				// Generate the handlers (this can probably GO soon)
+				Controller.generateBootTypeHanders()
 			}
+			// // Parse the boot configuration (preload ISOs etc.)
+			// err = Controller.ParseBootController()
+			// if err != nil {
+			// 	w.Header().Set("Content-Type", "application/json")
+			// 	rsp.Warning = "Error updating Server Configuration"
+			// 	rsp.Error = err.Error()
+			// }
 		}
 
 		json.NewEncoder(w).Encode(rsp)

--- a/pkg/services/serverHTTP.go
+++ b/pkg/services/serverHTTP.go
@@ -17,15 +17,16 @@ var controller *BootController
 
 var serveMux *http.ServeMux
 
+// TODO - this should be removed
 func (c *BootController) generateBootTypeHanders() {
 
 	// Find the default configuration
 	defaultConfig := findBootConfigForType("default")
 	if defaultConfig != nil {
 		defaultBoot = utils.IPXEPreeseed(*c.HTTPAddress, defaultConfig.Kernel, defaultConfig.Initrd, defaultConfig.Cmdline)
-	} else {
-		log.Warnf("Found [%d] configurations and no \"default\" configuration", len(c.BootConfigs))
-	}
+	} //else {
+	//	log.Warnf("Found [%d] configurations and no \"default\" configuration", len(c.BootConfigs))
+	//}
 
 	// If a preeseed configuration has been configured then add it, and create a HTTP endpoint
 	preeseedConfig := findBootConfigForType("preseed")

--- a/pkg/services/serverHTTPISO.go
+++ b/pkg/services/serverHTTPISO.go
@@ -187,12 +187,5 @@ func OpenISO(isoPath, isoPrefix string) error {
 		return fmt.Errorf("Error reading file [%s]", isoPath)
 	}
 
-	if isoMapper == nil {
-		// Ensure it is initialised before trying to use it
-		isoMapper = make(map[string]string)
-	}
-	// Add the reader
-	isoMapper[isoPrefix] = isoPath
-
 	return nil
 }

--- a/pkg/services/serverImageHTTP.go
+++ b/pkg/services/serverImageHTTP.go
@@ -1,0 +1,99 @@
+package services
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/dustin/go-humanize"
+)
+
+// WriteCounter counts the number of bytes written to it. It implements to the io.Writer interface
+// and we can pass this into io.TeeReader() which will report progress on each write cycle.
+type WriteCounter struct {
+	Total uint64
+}
+
+var data []byte
+
+func (wc *WriteCounter) Write(p []byte) (int, error) {
+	n := len(p)
+	wc.Total += uint64(n)
+	return n, nil
+}
+
+func tickerProgress(byteCounter uint64) {
+	// Clear the line by using a character return to go back to the start and remove
+	// the remaining characters by filling it with spaces
+	fmt.Printf("\r%s", strings.Repeat(" ", 35))
+
+	// Return again and print current status of download
+	// We use the humanize package to print the bytes in a meaningful way (e.g. 10 MB)
+	fmt.Printf("\rDownloading... %s complete", humanize.Bytes(byteCounter))
+	fmt.Println("")
+}
+
+func imageHandler(w http.ResponseWriter, r *http.Request) {
+
+	log.Infof("Incoming image from [%s]", r.RemoteAddr)
+
+	r.ParseMultipartForm(32 << 20)
+	file, handler, err := r.FormFile("BootyImage")
+	if handler != nil {
+		log.Infof("Beginning to recieve image [%s]", handler.Filename)
+	}
+
+	if err != nil {
+		log.Errorf("%v", err)
+		return
+	}
+	defer file.Close()
+
+	out, err := os.OpenFile(handler.Filename, os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		log.Fatalf("%v", err)
+	}
+	defer out.Close()
+
+	// Create our progress reporter and pass it to be used alongside our writer
+	ticker := time.NewTicker(500 * time.Millisecond)
+	counter := &WriteCounter{}
+
+	go func() {
+		for ; true; <-ticker.C {
+			tickerProgress(counter.Total)
+		}
+	}()
+	if _, err = io.Copy(out, io.TeeReader(file, counter)); err != nil {
+		log.Errorf("%v", err)
+	}
+
+	log.Infof("Written of image [%s] to disk", handler.Filename)
+	ticker.Stop()
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func configHandler(w http.ResponseWriter, r *http.Request) {
+	w.Write(data)
+}
+
+// Serve will start the webserver for BOOTy images
+func (c *BootController) serveImageHTTP() error {
+
+	fs := http.FileServer(http.Dir("./images"))
+	http.HandleFunc("/image", imageHandler)
+	http.Handle("/images/", http.StripPrefix("/images/", fs))
+	log.Println("Plunder OS Image Services --> Starting HTTP :3000")
+	err := http.ListenAndServe(":3000", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return nil
+}

--- a/pkg/services/templateBOOTy.go
+++ b/pkg/services/templateBOOTy.go
@@ -11,7 +11,17 @@ import (
 //BuildBOOTYconfig - Creates a new presseed configuration using the passed data
 func (config *HostConfig) BuildBOOTYconfig() string {
 	a := types.BootyConfig{}
-	a.Action = types.WriteImage
+
+	// set the required action
+	a.Action = config.BOOTYAction
+
+	// Default to false if not in configuration
+	if config.Compressed == nil {
+		a.Compressed = false
+	} else {
+		a.Compressed = *config.Compressed
+	}
+
 	// Parse the strings
 	subnet := net.ParseIP(config.Subnet)
 	ip := net.ParseIP(config.IPAddress)
@@ -29,12 +39,31 @@ func (config *HostConfig) BuildBOOTYconfig() string {
 		a.Gateway = config.Gateway
 	}
 
+	// READ
 	a.DestinationDevice = config.DestinationDevice
 	a.SourceImage = config.SourceImage
-	a.GrowPartition = *config.GrowPartition
+	// WRITE
+	a.DesintationAddress = config.DestinationAddress
+	a.SourceDevice = config.SourceDevice
+
+	// Default to false if not in configuration
+	if config.GrowPartition == nil {
+		a.GrowPartition = 0
+	} else {
+		a.GrowPartition = *config.GrowPartition
+	}
 	a.LVMRootName = config.LVMRootName
+
+	// Default to false if not in configuration
+	if config.ShellOnFail == nil {
+		a.DropToShell = false
+	} else {
+		a.DropToShell = *config.ShellOnFail
+	}
+
 	a.DropToShell = *config.ShellOnFail
 	a.NameServer = config.NameServer
+
 	b, _ := json.Marshal(a)
 	return string(b)
 }

--- a/pkg/services/templateUtils.go
+++ b/pkg/services/templateUtils.go
@@ -99,6 +99,15 @@ func (c *HostConfig) PopulateFromGlobalConfiguration(globalConfig HostConfig) {
 	}
 
 	// BOOTy configuration (TODO CAN NOT LEAVE THIS HERE)
+
+	if c.BOOTYAction == "" {
+		c.BOOTYAction = globalConfig.BOOTYAction
+	}
+
+	if c.Compressed == nil && globalConfig.Compressed != nil {
+		c.Compressed = globalConfig.Compressed
+	}
+
 	if c.GrowPartition == nil && globalConfig.GrowPartition != nil {
 		c.GrowPartition = globalConfig.GrowPartition
 	}
@@ -107,12 +116,22 @@ func (c *HostConfig) PopulateFromGlobalConfiguration(globalConfig HostConfig) {
 		c.LVMRootName = globalConfig.LVMRootName
 	}
 
+	// WRITE to server
 	if c.DestinationDevice == "" {
 		c.DestinationDevice = globalConfig.DestinationDevice
 	}
 
 	if c.SourceImage == "" {
 		c.SourceImage = globalConfig.SourceImage
+	}
+
+	// READ from server
+	if c.DestinationAddress == "" {
+		c.DestinationAddress = globalConfig.DestinationAddress
+	}
+
+	if c.SourceDevice == "" {
+		c.SourceDevice = globalConfig.SourceDevice
 	}
 
 	// TODO

--- a/pkg/services/types.go
+++ b/pkg/services/types.go
@@ -27,11 +27,12 @@ type BootController struct {
 }
 
 type dhcpConfig struct {
-	DHCPAddress      *string `json:"addressDHCP"`    // Should ideally be the IP of the adapter
-	DHCPStartAddress *string `json:"startDHCP"`      // The first available DHCP address
-	DHCPLeasePool    *int    `json:"leasePoolDHCP"`  // Size of the IP Address pool
-	DHCPGateway      *string `json:"gatewayDHCP"`    // Gatewway to advertise
-	DHCPDNS          *string `json:"nameserverDHCP"` // DNS server to advertise
+	DHCPAddress      string `json:"addressDHCP"`    // Should ideally be the IP of the adapter
+	DHCPStartAddress string `json:"startDHCP"`      // The first available DHCP address
+	DHCPLeasePool    int    `json:"leasePoolDHCP"`  // Size of the IP Address pool
+	DHCPSubnet       string `json:"subnetDHCP"`     // Subnet for leases
+	DHCPGateway      string `json:"gatewayDHCP"`    // Gateway to advertise
+	DHCPDNS          string `json:"nameserverDHCP"` // DNS server to advertise
 }
 
 // BootConfig defines a named configuration for booting
@@ -95,9 +96,16 @@ type HostConfig struct {
 	Packages string `json:"packages,omitempty"`
 
 	// OS Image provisioning
+	BOOTYAction string `json:"bootyAction,omitempty"`
+	Compressed  *bool  `json:"compressed,omitempty"`
+
 	// Write image to disk from remote address
 	SourceImage       string `json:"sourceImage,omitempty"`
 	DestinationDevice string `json:"destinationDevice,omitempty"`
+
+	// Read image from disk from remote address
+	SourceDevice       string `json:"sourceDevice,omitempty"`
+	DestinationAddress string `json:"destinationAddress,omitempty"`
 
 	// Post tasks - Once the image has been deployed
 

--- a/pkg/utils/nic.go
+++ b/pkg/utils/nic.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"fmt"
-	"log"
 	"net"
 )
 
@@ -69,14 +68,14 @@ func FindAllIPAddresses() ([]net.IP, error) {
 }
 
 //ConvertIP -
-func ConvertIP(ipAddress string) []byte {
+func ConvertIP(ipAddress string) ([]byte, error) {
 	// net.ParseIP has returned IPv6 sized allocations o_O
 	fixIP := net.ParseIP(ipAddress)
 	if fixIP == nil {
-		log.Fatalf("Couldn't parse the IP address: %s\n", ipAddress)
+		return nil, fmt.Errorf("Couldn't parse the IP address: %s", ipAddress)
 	}
 	if len(fixIP) > 4 {
-		return fixIP[len(fixIP)-4:]
+		return fixIP[len(fixIP)-4:], nil
 	}
-	return fixIP
+	return fixIP, nil
 }


### PR DESCRIPTION
This Branch pulls in a list of additional features and fixes:

*BOOTy*
Added in additional types and defaults being set, along with updates to the template generation.

*BOOT TYPES*
We can now generate multiple boot configurations that can use the OS provisioning templates

*ISO*
Fixes to isopath and a logic error when adding a broken path.

*DHCP*
Customisable Subnet